### PR TITLE
Fix error on Align Self (self-end)

### DIFF
--- a/lib/config/groups.js
+++ b/lib/config/groups.js
@@ -257,7 +257,7 @@ module.exports.groups = [
       },
       {
         type: 'Align Self',
-        members: 'items\\-(auto|start|end|center|stretch)',
+        members: 'self\\-(auto|start|end|center|stretch)',
       },
       {
         type: 'Place Content',

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -28,7 +28,7 @@ var ruleTester = new RuleTester({ parserOptions });
 ruleTester.run("no-custom-classname", rule, {
   valid: [
     {
-      code: `<div class="container box-content lg:box-border max-h-24">Only Tailwind CSS classnames</div>`,
+      code: `<div class="container box-content lg:box-border max-h-24 self-end">Only Tailwind CSS classnames</div>`,
     },
     {
       code: `


### PR DESCRIPTION
# Fix error on Align Self

## Description

Fixes a bug where this plugin treated the tailwind class `self-end` as a custom class.

See: https://tailwindcss.com/docs/align-self

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* OS + version: MacOS Big Sur
* NPM version: 6.4.12
* Node version: 14.16.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
