### PR TITLE
Fix theme object access

### DIFF
--- a/lib/util/groupMethods.js
+++ b/lib/util/groupMethods.js
@@ -41,7 +41,7 @@ function generateOptions(propName, keys, config, isNegative = false) {
     case 'ringOffsetColor':
       const options = [];
       keys.forEach((k) => {
-        const color = config.theme[propName]?.[k] || config.theme.colors[k];
+        const color = config.theme[propName][k] || config.theme.colors[k];
         if (typeof color === 'string') {
           options.push(escapeSpecialChars(k));
         } else {


### PR DESCRIPTION
# Fix theme object access
## Description

Fix syntax error of `config.theme[propName]?.[k]`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The error was a syntax one, so i just run the script

**Test Configuration**:
* OS + version: macOS 11.2.3
* NPM version: 7.14.0
* Node version: 15.12.0

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
