### PR TITLE
feat: add support for tagged templates

### DIFF
--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -58,6 +58,11 @@ module.exports = {
             default: true,
             type: 'boolean',
           },
+          tags: {
+            type: 'array',
+            items: { type: 'string', minLength: 0 },
+            uniqueItems: true,
+          },
         },
       },
     ],
@@ -65,6 +70,7 @@ module.exports = {
 
   create: function (context) {
     const callees = getOption(context, 'callees');
+    const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
     const groupsConfig = getOption(context, 'groups');
     const groupByResponsive = getOption(context, 'groupByResponsive');
@@ -332,6 +338,13 @@ module.exports = {
         node.arguments.forEach((arg) => {
           sortNodeArgumentValue(node, arg);
         });
+      },
+      TaggedTemplateExpression: function (node) {
+        if (!tags.includes(node.tag.name)) {
+          return;
+        }
+
+        sortNodeArgumentValue(node, node.quasi);
       },
     };
     const templateVisitor = {

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -46,6 +46,11 @@ module.exports = {
             default: 'tailwind.config.js',
             type: ['string', 'object'],
           },
+          tags: {
+            type: 'array',
+            items: { type: 'string', minLength: 0 },
+            uniqueItems: true,
+          },
         },
       },
     ],
@@ -53,6 +58,7 @@ module.exports = {
 
   create: function (context) {
     const callees = getOption(context, 'callees');
+    const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
 
     const mergedConfig = customConfig.resolve(twConfig);
@@ -145,6 +151,24 @@ module.exports = {
         node.arguments.forEach((arg) => {
           astUtil.parseNodeRecursive(node, arg, pushClasses, true);
         });
+        parseForContradictingClassNames(allClassnamesForNode, node);
+      },
+      TaggedTemplateExpression: function (node) {
+        if (!tags.includes(node.tag.name)) {
+          return;
+        }
+
+        const allClassnamesForNode = [];
+        const pushClasses = (classNames, targetNode) => {
+          if (targetNode === null) {
+            // Classnames should be parsed in isolation (e.g. conditional expressions)
+            parseForContradictingClassNames(classNames, node);
+          } else {
+            // Gather the classes prior to validation
+            allClassnamesForNode.push(...classNames);
+          }
+        };
+        astUtil.parseNodeRecursive(node, node.quasi, pushClasses, true);
         parseForContradictingClassNames(allClassnamesForNode, node);
       },
     };

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -52,6 +52,11 @@ module.exports = {
             items: { type: 'string', minLength: 0 },
             uniqueItems: true,
           },
+          tags: {
+            type: 'array',
+            items: { type: 'string', minLength: 0 },
+            uniqueItems: true,
+          },
           whitelist: {
             type: 'array',
             items: { type: 'string', minLength: 0 },
@@ -64,6 +69,7 @@ module.exports = {
 
   create: function (context) {
     const callees = getOption(context, 'callees');
+    const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
     const cssFiles = getOption(context, 'cssFiles');
     const whitelist = getOption(context, 'whitelist');
@@ -127,6 +133,12 @@ module.exports = {
         node.arguments.forEach((arg) => {
           astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames);
         });
+      },
+      TaggedTemplateExpression: function (node) {
+        if (!tags.includes(node.tag.name)) {
+          return;
+        }
+        astUtil.parseNodeRecursive(node, node.quasi, parseForCustomClassNames);
       },
     };
 

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -27,6 +27,8 @@ function getOption(context, name) {
       return false;
     case 'removeDuplicates':
       return true;
+    case 'tags':
+      return [];
     case 'whitelist':
       return [];
   }

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -140,6 +140,20 @@ ruleTester.run("classnames-order", rule, {
         },
       },
     },
+    {
+      code: `myTag\`
+        container
+        flex
+        w-12
+        sm:w-6
+        lg:w-4
+      \``,
+      options: [
+        {
+          tags: ["myTag"],
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -520,6 +534,93 @@ ruleTester.run("classnames-order", rule, {
       />
       `,
       errors: [
+        {
+          messageId: "invalidOrder",
+        },
+      ],
+    },
+    {
+      code: `
+      myTag\`
+        invalid
+        sm:w-6
+        container
+        w-12
+        flex
+        lg:w-4
+      \`;`,
+      output: `
+      myTag\`
+        container
+        flex
+        w-12
+        sm:w-6
+        lg:w-4
+        invalid
+      \`;`,
+      options: [
+        {
+          tags: ["myTag"],
+        },
+      ],
+      errors: errors,
+    },
+    {
+      code: `
+      const buttonClasses = myTag\`
+        \${fullWidth ? "w-12" : "w-6"}
+        container
+        \${fullWidth ? "sm:w-8" : "sm:w-4"}
+        lg:w-9
+        flex
+        \${hasError && "bg-red"}
+      \`;`,
+      output: `
+      const buttonClasses = myTag\`
+        \${fullWidth ? "w-12" : "w-6"}
+        container
+        \${fullWidth ? "sm:w-8" : "sm:w-4"}
+        flex
+        lg:w-9
+        \${hasError && "bg-red"}
+      \`;`,
+      options: [
+        {
+          tags: ["myTag"],
+        },
+      ],
+      errors: errors,
+    },
+    {
+      code: `
+      const buttonClasses = myTag\`
+        \${fullWidth ? "w-12" : "w-6"}
+        flex
+        container
+        \${fullWidth ? "sm:w-7" : "sm:w-4"}
+        lg:py-4
+        sm:py-6
+        \${hasError && "bg-red"}
+      \`;`,
+      output: `
+      const buttonClasses = myTag\`
+        \${fullWidth ? "w-12" : "w-6"}
+        container
+        flex
+        \${fullWidth ? "sm:w-7" : "sm:w-4"}
+        sm:py-6
+        lg:py-4
+        \${hasError && "bg-red"}
+      \`;`,
+      options: [
+        {
+          tags: ["myTag"],
+        },
+      ],
+      errors: [
+        {
+          messageId: "invalidOrder",
+        },
         {
           messageId: "invalidOrder",
         },

--- a/tests/lib/rules/no-contradicting-classname.js
+++ b/tests/lib/rules/no-contradicting-classname.js
@@ -88,6 +88,37 @@ ruleTester.run("no-contradicting-classname", rule, {
       \`)
       `,
     },
+    {
+      code: `
+      myTag\`
+        text-white
+        rounded-md
+        py-5
+        px-10
+        text-sm
+        \${
+          type === 'primary' &&
+          \`
+            bg-black
+            hover:bg-blue
+          \`
+        }
+        \${
+          type === 'secondary' &&
+          \`
+            bg-transparent
+            hover:bg-green
+          \`
+        }
+        disabled:cursor-not-allowed
+      \`
+      `,
+      options: [
+        {
+          tags: ["myTag"],
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -262,6 +293,83 @@ ruleTester.run("no-contradicting-classname", rule, {
     },
     {
       code: `ctl(\`\${enabled && "px-2 px-0"}\`)`,
+      errors: [
+        {
+          messageId: "conflictingClassnames",
+          data: {
+            classnames: "px-2, px-0",
+          },
+        },
+      ],
+    },
+
+    {
+      code: `
+      myTag\`
+        invalid bis
+        sm:w-6
+        w-8
+        container
+        w-12
+        flex
+        lg:w-4
+      \`;`,
+      options: [{ tags: ["myTag"] }],
+      errors: [
+        {
+          messageId: "conflictingClassnames",
+          data: {
+            classnames: "w-8, w-12",
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      myTag\`
+        px-2
+        px-4
+        \${
+          !isDisabled &&
+          \`
+            py-1
+            py-2
+          \`
+        }
+        \${
+          isDisabled &&
+          \`
+            w-1
+            w-2
+          \`
+        }
+      \`
+      `,
+      options: [{ tags: ["myTag"] }],
+      errors: [
+        {
+          messageId: "conflictingClassnames",
+          data: {
+            classnames: "py-1, py-2",
+          },
+        },
+        {
+          messageId: "conflictingClassnames",
+          data: {
+            classnames: "w-1, w-2",
+          },
+        },
+        {
+          messageId: "conflictingClassnames",
+          data: {
+            classnames: "px-2, px-4",
+          },
+        },
+      ],
+    },
+    {
+      code: `myTag\`\${enabled && "px-2 px-0"}\``,
+      options: [{ tags: ["myTag"] }],
       errors: [
         {
           messageId: "conflictingClassnames",

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -131,6 +131,19 @@ ruleTester.run("no-custom-classname", rule, {
         },
       ],
     },
+
+    {
+      code: `
+      myTag\`
+        sm:w-6
+        w-8
+        container
+        w-12
+        flex
+        lg:w-4
+      \`;`,
+      options: [{ tags: ["myTag"] }],
+    },
   ],
 
   invalid: [
@@ -347,6 +360,81 @@ ruleTester.run("no-custom-classname", rule, {
           messageId: "customClassnameDetected",
           data: {
             classname: "azerty",
+          },
+        },
+      ],
+    },
+
+    {
+      code: `
+      myTag\`
+        sm:w-6
+        hello
+        w-8
+        container
+        w-12
+        world
+        flex
+        lg:w-4
+      \`;`,
+      options: [{ tags: ["myTag"] }],
+      errors: [
+        {
+          messageId: "customClassnameDetected",
+          data: {
+            classname: "hello",
+          },
+        },
+        {
+          messageId: "customClassnameDetected",
+          data: {
+            classname: "world",
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      myTag\`
+        px-4
+        custom-1
+        py-1
+        \${
+          !isDisabled &&
+          \`
+            lg:focus:ring-1
+            custom-2
+            focus:ring-2
+          \`
+        }
+        \${
+          isDisabled &&
+          \`
+            lg:opacity-25
+            custom-3
+            opacity-50
+          \`
+        }
+      \`
+      `,
+      options: [{ tags: ["myTag"] }],
+      errors: [
+        {
+          messageId: "customClassnameDetected",
+          data: {
+            classname: "custom-2",
+          },
+        },
+        {
+          messageId: "customClassnameDetected",
+          data: {
+            classname: "custom-3",
+          },
+        },
+        {
+          messageId: "customClassnameDetected",
+          data: {
+            classname: "custom-1",
           },
         },
       ],


### PR DESCRIPTION
# Add support for tagged templates

## Description

I've added support for validating the rules against tagged templates. This means you could now validate e.g. ```const styles = myTag`block px-4`;```

Most of the code is copy-paste from the `CallExpression` implementations, so there could be potential for code de-duplication/refactoring here.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I've duplicated some of the tests you've added for validating `CallExpression`s (`ctl(...)` & `clsx(...)`) and adjusted them to `TaggedTemplateExpression`s instead.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
