### PR TITLE
Performance gains on `no-custom-classname` and `no-contradicting-classname`

### DIFF
--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -61,6 +61,9 @@ module.exports = {
     // Helpers
     //----------------------------------------------------------------------
 
+    // Init assets before sorting
+    const groups = groupUtil.getGroups(defaultGroups, mergedConfig);
+
     /**
      * Parse the classnames and report found conflicts
      * @param {Array} classNames
@@ -69,7 +72,6 @@ module.exports = {
     const parseForContradictingClassNames = (classNames, node) => {
       classNames = attrUtil.sanitizeClassnames(classNames);
       // Init assets before sorting
-      const groups = groupUtil.getGroups(defaultGroups, mergedConfig);
       const sorted = groupUtil.initGroupSlots(groups);
 
       // Move each classname inside its dedicated group

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -74,6 +74,10 @@ module.exports = {
     // Helpers
     //----------------------------------------------------------------------
 
+    // Init assets before sorting
+    const groups = groupUtil.getGroups(defaultGroups, mergedConfig);
+    const classnamesFromFiles = getClassnamesFromCSS(cssFiles);
+
     /**
      * Parse the classnames and report found conflicts
      * @param {Array} classNames
@@ -81,9 +85,6 @@ module.exports = {
      */
     const parseForCustomClassNames = (classNames, node) => {
       classNames = attrUtil.sanitizeClassnames(classNames);
-      // Init assets before sorting
-      const groups = groupUtil.getGroups(defaultGroups, mergedConfig);
-      const classnamesFromFiles = getClassnamesFromCSS(cssFiles);
 
       classNames.forEach((className) => {
         const idx = groupUtil.getGroupIndex(className, groups, mergedConfig.separator);


### PR DESCRIPTION
# Performance gains on `no-custom-classname` and `no-contradicting-classname`

## Description

I noticed that the rules are spending a lot of time doing group generation, which seems to be a good candidate for improving the performance of the rules. I tried moving the generation out of the hot code paths, which seems to have improved the performance tremendously, especially for the `no-custom-classname` rule.

Running my eslint config on my repository resulted in the following timings, before and after these changes have been applied. As you see, both of the changed rules have fallen out of the "after" chart, meaning that it's no longer a part of the top 10 slowest rules.

**Before:**

```
❯ TIMING=1 yarn lint
Rule                                    | Time (ms) | Relative
:---------------------------------------|----------:|--------:
tailwindcss/no-custom-classname         | 31050.121 |    48.3%
@typescript-eslint/no-unsafe-assignment | 12956.041 |    20.2%
import/no-cycle                         | 10103.254 |    15.7%
tailwindcss/classnames-order            |  1688.545 |     2.6%
import/no-extraneous-dependencies       |  1312.942 |     2.0%
@typescript-eslint/no-unsafe-return     |   847.112 |     1.3%
tailwindcss/no-contradicting-classname  |   718.735 |     1.1%
@typescript-eslint/no-floating-promises |   651.277 |     1.0%
import/export                           |   504.332 |     0.8%
@typescript-eslint/no-redeclare         |   344.194 |     0.5%
```

**After:**

```
❯ TIMING=1 yarn lint
Rule                                    | Time (ms) | Relative
:---------------------------------------|----------:|--------:
@typescript-eslint/no-unsafe-assignment | 12148.495 |    39.4%
import/no-cycle                         |  9446.505 |    30.6%
tailwindcss/classnames-order            |  1458.653 |     4.7%
import/no-extraneous-dependencies       |  1196.246 |     3.9%
@typescript-eslint/no-floating-promises |   821.758 |     2.7%
@typescript-eslint/no-unsafe-return     |   782.569 |     2.5%
import/export                           |   480.280 |     1.6%
@typescript-eslint/no-redeclare         |   402.356 |     1.3%
import/order                            |   267.323 |     0.9%
@typescript-eslint/no-misused-promises  |   212.630 |     0.7%
```

I'm not sure if the changes I've made are a good idea or not, so I'll leave that decision up to you.
I see there's some `REFRESH_RATE` stuff going on in the `generateClassnamesListSync`, which this PR probably interferes with in some way.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Haven't tested this too much. The changes are very simple, but it looks like it may break some of the functionality related to continuous refresh of the files from the "classnames from file" feature - which I guess is mostly useful when eslint is run as a extension in VS Code (?).

**Test Configuration**:
* OS + version: Debian 10
* Node version: 16.3.0

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
