### PR TITLE
Fix using incorrect plugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ module.exports = {
   },
   configs: {
     recommended: {
-      plugins: ['tailwind'],
+      plugins: ['tailwindcss'],
       parserOptions: {
         ecmaFeatures: {
           jsx: true,


### PR DESCRIPTION
# Fix using incorrect plugin

## Description

Currently causes `ESLint couldn't find the plugin "eslint-plugin-tailwind".`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I must admit, I have not tested it, as it's simply a one word fix on a regression. Let me know if you'd like me to run anything.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
