### PR TITLE
Fix `no-custom-classname` sample code

### DIFF
--- a/docs/rules/no-custom-classname.md
+++ b/docs/rules/no-custom-classname.md
@@ -22,9 +22,10 @@ Examples of **correct** code for this rule:
 
 ```js
 ...
-"tailwindcss/classnames-order": [<enabled>, {
+"tailwindcss/no-custom-classname": [<enabled>, {
   "callees": Array<string>,
   "config": <string>|<object>,
+  "cssFiles": Array<string>,
   "whitelist": Array<string>
 }]
 ...


### PR DESCRIPTION
Add `cssFiles` option and use correct rule name. I suppose this was a copy and paste from another rule's docs but the code sample was not updated.