### PR TITLE
fix: correctly handle number values in config

### DIFF
--- a/lib/util/groupMethods.js
+++ b/lib/util/groupMethods.js
@@ -318,7 +318,7 @@ function patchRegex(re, config) {
         if (isNegative) {
           // Negative prop cannot support NaN values and inherits positive values
           const val = config.theme[absoluteProp][key];
-          const isCalc = val.indexOf('calc') === 0;
+          const isCalc = typeof val === 'string' && val.indexOf('calc') === 0;
           const num = parseFloat(val);
           if (isCalc) {
             return true;

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -162,6 +162,14 @@ ruleTester.run("classnames-order", rule, {
         },
       ],
     },
+    {
+      code: `<div class="flex z-dialog w-12">Number values</div>`,
+      settings: {
+        tailwindcss: {
+          config: { theme: { zIndex: { dialog: 10000 } } },
+        },
+      },
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Feel free to edit/close/etc.

# Pull Request Name
Correctly handle number values in config.

## Description

Given this Tailwind config:

```ts
module.exports = {
  theme: {
      zIndex: {
        dialog: 10000,
      },
  }
}
```

The lint task fails with

```
TypeError: Error while loading rule 'tailwindcss/no-contradicting-classname': val.indexOf is not a function
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Test is included in the PR

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* OS + version: e.g. macOS Mojave
* NPM version: ...
* Node version: ...

-->

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
