### PR TITLE
Refactor/speed improvement 2

### DIFF
--- a/lib/util/cssFiles.js
+++ b/lib/util/cssFiles.js
@@ -18,7 +18,7 @@ let classnamesFromFiles = [];
 const generateClassnamesListSync = (patterns) => {
   const now = new Date().getTime();
   const files = fg.sync(patterns);
-  const newGlobs = previousGlobsResults.flat().join(',') != files.flat().join('');
+  const newGlobs = previousGlobsResults.flat().join(',') != files.flat().join(',');
   const expired = now - lastUpdate > REFRESH_RATE;
   if (newGlobs || expired) {
     previousGlobsResults = files;

--- a/lib/util/cssFiles.js
+++ b/lib/util/cssFiles.js
@@ -17,25 +17,27 @@ let classnamesFromFiles = [];
  */
 const generateClassnamesListSync = (patterns) => {
   const now = new Date().getTime();
-  const files = fg.sync(patterns);
-  const newGlobs = previousGlobsResults.flat().join(',') != files.flat().join(',');
   const expired = now - lastUpdate > REFRESH_RATE;
-  if (newGlobs || expired) {
-    previousGlobsResults = files;
+  if (expired) {
     lastUpdate = now;
-    let detectedClassnames = [];
-    for (const file of files) {
-      const data = fs.readFileSync(file, 'utf-8');
-      const root = postcss.parse(data);
-      root.walkRules((rule) => {
-        const regexp = /\.([^\.\,\s\n\:\(\)\[\]\'~\+\>\*\\]*)/gim;
-        const matches = [...rule.selector.matchAll(regexp)];
-        const classnames = matches.map((arr) => arr[1]);
-        detectedClassnames.push(...classnames);
-      });
-      detectedClassnames = removeDuplicatesFromArray(detectedClassnames);
+    const files = fg.sync(patterns);
+    const newGlobs = previousGlobsResults.flat().join(',') != files.flat().join(',');
+    if (newGlobs) {
+      previousGlobsResults = files;
+      let detectedClassnames = [];
+      for (const file of files) {
+        const data = fs.readFileSync(file, 'utf-8');
+        const root = postcss.parse(data);
+        root.walkRules((rule) => {
+          const regexp = /\.([^\.\,\s\n\:\(\)\[\]\'~\+\>\*\\]*)/gim;
+          const matches = [...rule.selector.matchAll(regexp)];
+          const classnames = matches.map((arr) => arr[1]);
+          detectedClassnames.push(...classnames);
+        });
+        detectedClassnames = removeDuplicatesFromArray(detectedClassnames);
+      }
+      classnamesFromFiles = detectedClassnames;
     }
-    classnamesFromFiles = detectedClassnames;
   }
   return classnamesFromFiles;
 };


### PR DESCRIPTION
# Speed Improvements with cssFiles

This code change is best observed without whitespace. https://github.com/francoismassart/eslint-plugin-tailwindcss/pull/93/files?diff=split&w=1

## Description

This is an alternative approach to https://github.com/francoismassart/eslint-plugin-tailwindcss/pull/92.

After trying `v2.0.0-beta` I still observed that the execution time was too long. My suspicion is that maybe we don't _need_ to call `fg.sync` if the previous `fg.sync` results have not expired.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* OS + version: e.g. macOS Mojave
* NPM version: ...
* Node version: ...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
