### PR TITLE
FIXES for `no-custom-classname`

### DIFF
--- a/lib/util/groupMethods.js
+++ b/lib/util/groupMethods.js
@@ -40,7 +40,7 @@ function escapeSpecialChars(str) {
  */
 function generateOptionalOpacitySuffix(config) {
   const opacityKeys = !config.theme['opacity'] ? [] : Object.keys(config.theme['opacity']);
-  opacityKeys.push('\\[(0|1|0?\\.\\d{1,})\\]');
+  opacityKeys.push('\\[(\\d*\\.?\\d*)%?\\]');
   return `(\\/(${opacityKeys.join('|')}))?`;
 }
 

--- a/lib/util/groupMethods.js
+++ b/lib/util/groupMethods.js
@@ -29,7 +29,7 @@ const length = require('./types/length');
  * @returns {String} Escaped version
  */
 function escapeSpecialChars(str) {
-  return str.replace(/[\-\.\/]/g, '\\$&');
+  return str.replace(/[\-\.\/\(\)]/g, '\\$&');
 }
 
 /**
@@ -61,13 +61,14 @@ function generateOptions(propName, keys, config, isNegative = false) {
   if (defaultKeyIndex > -1) {
     keys.splice(defaultKeyIndex, 1);
   }
+  const escapedKeys = keys.map((k) => escapeSpecialChars(k));
   switch (propName) {
     case 'dark':
       // Optional `dark` class
       return config.darkMode === 'class' ? 'dark' : '';
     case 'arbitraryProperties':
-      keys.push(genericArbitraryOption);
-      return '(' + keys.join('|') + ')';
+      escapedKeys.push(genericArbitraryOption);
+      return '(' + escapedKeys.join('|') + ')';
     case 'accentColor':
     case 'backgroundColor':
     case 'borderColor':
@@ -131,19 +132,19 @@ function generateOptions(propName, keys, config, isNegative = false) {
     case 'ringWidth':
     case 'ringOffsetWidth':
     case 'textUnderlineOffset':
-      keys.push(length.selectedUnitsRegEx);
-      keys.push(length.anyCalcRegEx);
+      escapedKeys.push(length.selectedUnitsRegEx);
+      escapedKeys.push(length.anyCalcRegEx);
       // Mandatory `length:` prefix + wildcard
-      keys.push(`\\[length\\:.{1,}\\]`);
-      return '(' + keys.join('|') + ')';
+      escapedKeys.push(`\\[length\\:.{1,}\\]`);
+      return '(' + escapedKeys.join('|') + ')';
     case 'strokeWidth':
-      keys.push(length.selectedUnitsRegEx);
-      keys.push(length.anyCalcRegEx);
+      escapedKeys.push(length.selectedUnitsRegEx);
+      escapedKeys.push(length.anyCalcRegEx);
       // Mandatory `length:` prefix + calc + wildcard
-      keys.push(`\\[length\\:calc\\(.{1,}\\)\\]`);
+      escapedKeys.push(`\\[length\\:calc\\(.{1,}\\)\\]`);
       // Mandatory `length:` prefix + wildcard + optional units
-      keys.push(`\\[length\\:(.{1,})(${length.selectedUnits.join('|')})?\\]`);
-      return '(' + keys.join('|') + ')';
+      escapedKeys.push(`\\[length\\:(.{1,})(${length.selectedUnits.join('|')})?\\]`);
+      return '(' + escapedKeys.join('|') + ')';
     case 'gap':
     case 'height':
     case 'lineHeight':
@@ -177,11 +178,11 @@ function generateOptions(propName, keys, config, isNegative = false) {
     case 'cursor':
       if (supportArbitrary) {
         // All units
-        keys.push(length.mergedUnitsRegEx);
+        escapedKeys.push(length.mergedUnitsRegEx);
         // Forbidden prefixes
-        keys.push(`\\[(?!(angle|color|length|list)\:).{1,}\\]`);
+        escapedKeys.push(`\\[(?!(angle|color|length|list)\:).{1,}\\]`);
       }
-      return '(' + keys.join('|') + ')';
+      return '(' + escapedKeys.join('|') + ')';
     case 'backdropHueRotate':
     case 'hueRotate':
     case 'inset':
@@ -194,23 +195,23 @@ function generateOptions(propName, keys, config, isNegative = false) {
     case 'translate':
       if (supportArbitrary) {
         // All units
-        keys.push(length.mergedUnitsRegEx);
+        escapedKeys.push(length.mergedUnitsRegEx);
         // Forbidden prefixes
-        keys.push(`\\[(?!(angle|color|length|list)\:).{1,}\\]`);
+        escapedKeys.push(`\\[(?!(angle|color|length|list)\:).{1,}\\]`);
       }
-      return '(' + keys.join('|') + ')';
+      return '(' + escapedKeys.join('|') + ')';
     case 'opacity':
       // 0 ... .5 ... 1
-      keys.push(`\\[(0(\\.\\d{1,})?|\\.\\d{1,}|1)\\]`);
-      keys.push(length.anyCalcRegEx);
+      escapedKeys.push(`\\[(0(\\.\\d{1,})?|\\.\\d{1,}|1)\\]`);
+      escapedKeys.push(length.anyCalcRegEx);
       // Unprefixed var()
-      keys.push(`\\[var\\(\\-\\-[A-Za-z\\-]{1,}\\)\\]`);
-      return '(' + keys.join('|') + ')';
+      escapedKeys.push(`\\[var\\(\\-\\-[A-Za-z\\-]{1,}\\)\\]`);
+      return '(' + escapedKeys.join('|') + ')';
     case 'rotate':
       if (supportArbitrary) {
-        keys.push(`\\[(${angle.mergedAngleValues.join('|')})\\]`);
+        escapedKeys.push(`\\[(${angle.mergedAngleValues.join('|')})\\]`);
       }
-      return '(' + keys.join('|') + ')';
+      return '(' + escapedKeys.join('|') + ')';
     case 'gridTemplateColumns':
     case 'gridColumn':
     case 'gridColumnStart':
@@ -222,42 +223,42 @@ function generateOptions(propName, keys, config, isNegative = false) {
     case 'gridAutoColumns':
     case 'gridAutoRows':
       // Forbidden prefixes
-      keys.push(`\\[(?!(angle|color|length)\:).{1,}\\]`);
-      return '(' + keys.join('|') + ')';
+      escapedKeys.push(`\\[(?!(angle|color|length)\:).{1,}\\]`);
+      return '(' + escapedKeys.join('|') + ')';
     case 'listStyleType':
       // Forbidden prefixes
-      keys.push(`\\[(?!(angle|color|length|list)\:).{1,}\\]`);
-      return '(' + keys.join('|') + ')';
+      escapedKeys.push(`\\[(?!(angle|color|length|list)\:).{1,}\\]`);
+      return '(' + escapedKeys.join('|') + ')';
     case 'objectPosition':
       // Forbidden prefixes
-      keys.push(`\\[(?!(angle|color|length)\:).{1,}\\]`);
-      return '(' + keys.join('|') + ')';
+      escapedKeys.push(`\\[(?!(angle|color|length)\:).{1,}\\]`);
+      return '(' + escapedKeys.join('|') + ')';
     case 'backgroundPosition':
     case 'boxShadow':
     case 'dropShadow':
     case 'transitionProperty':
       // Forbidden prefixes
-      keys.push(`\\[(?!((angle|color|length|list)\:)|var\\().{1,}\\]`);
-      return '(' + keys.join('|') + ')';
+      escapedKeys.push(`\\[(?!((angle|color|length|list)\:)|var\\().{1,}\\]`);
+      return '(' + escapedKeys.join('|') + ')';
     case 'backgroundSize':
       // Forbidden prefixes
-      keys.push(`\\[length\:.{1,}\\]`);
-      return '(' + keys.join('|') + ')';
+      escapedKeys.push(`\\[length\:.{1,}\\]`);
+      return '(' + escapedKeys.join('|') + ')';
     case 'backgroundImage':
       // Forbidden prefixes
-      keys.push(`\\[url\\(.{1,}\\)\\]`);
-      return '(' + keys.join('|') + ')';
+      escapedKeys.push(`\\[url\\(.{1,}\\)\\]`);
+      return '(' + escapedKeys.join('|') + ')';
     case 'order':
     case 'zIndex':
       if (supportArbitrary) {
-        keys.push(genericArbitraryOption);
+        escapedKeys.push(genericArbitraryOption);
       }
-      return '(' + keys.join('|') + ')';
+      return '(' + escapedKeys.join('|') + ')';
     case 'fontWeight':
     case 'typography':
     case 'lineClamp':
       // Cannot be arbitrary?
-      return '(' + keys.join('|') + ')';
+      return '(' + escapedKeys.join('|') + ')';
     case 'aspectRatio':
     case 'flexGrow':
     case 'flexShrink':
@@ -265,8 +266,8 @@ function generateOptions(propName, keys, config, isNegative = false) {
     case 'flex':
     case 'borderRadius':
     default:
-      keys.push(genericArbitraryOption);
-      return '(' + keys.join('|') + ')';
+      escapedKeys.push(genericArbitraryOption);
+      return '(' + escapedKeys.join('|') + ')';
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwindcss",
-  "version": "3.2.0",
+  "version": "3.2.1-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwindcss",
-  "version": "3.2.1-beta.0",
+  "version": "3.2.1-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwindcss",
-  "version": "3.2.1-beta.0",
+  "version": "3.2.1-beta.2",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwindcss",
-  "version": "3.2.0",
+  "version": "3.2.1-beta.0",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -525,6 +525,23 @@ ruleTester.run("no-custom-classname", rule, {
       code: `
       <div className="transform-none">Disabling transform</div>`,
     },
+    {
+      code: `
+      <div className="text-9xl text-ffffff/[24%] bg-000000">Issue #101</div>`,
+      options: [
+        {
+          config: {
+            theme: {
+              colors: {
+                "000000": "#000000",
+                ffffff: "#ffffff",
+              },
+            },
+            plugins: [],
+          },
+        },
+      ],
+    },
   ],
 
   invalid: [

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -542,6 +542,24 @@ ruleTester.run("no-custom-classname", rule, {
         },
       ],
     },
+    {
+      code: `
+      <div className="grid gap-x-4 grid-cols-1fr/minmax(0/360)/1fr">Issue #100</div>`,
+      options: [
+        {
+          config: {
+            theme: {
+              extend: {
+                gridTemplateColumns: {
+                  "1fr/minmax(0/360)/1fr": "1fr minmax(0, calc(360 * .25rem)) 1fr",
+                },
+              },
+            },
+            plugins: [],
+          },
+        },
+      ],
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
# FIXES for `no-custom-classname`

## Description

Fixes #100 Using parentheses in the class name causes an error in the "tailwindcss/no-custom-classname" rule
Fixes #101 Using the percent symbol in square brackets of the class name causes an error in the "tailwindcss/no-custom-classname" rule

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
