### PR TITLE
fix: support `not-prose`

### DIFF
--- a/lib/config/groups.js
+++ b/lib/config/groups.js
@@ -1323,7 +1323,7 @@ module.exports.groups = [
         members: [
           {
             type: 'prose',
-            members: 'prose',
+            members: '(not\\-)?prose',
           },
           {
             type: 'prose-modifier',


### PR DESCRIPTION
# Support `not-prose`

## Description

`not-prose` is a class of `@tailwindcss/typography`. Before this change, using `not-prose` caused the `tailwindcss/no-custom-classname` error. With the change, this error has disappeared.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `prose` and `not-prose` do not cause any errors.
- [x] `foo-prose` causes a `tailwindcss/no-custom-classname` error.

**Test Configuration**:
* OS + version: macOS Monterey
* NPM version: 8.5.0
* Node version: 16.14.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
