### PR TITLE
feat: allow linting specified variables

### DIFF
--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -21,6 +21,8 @@ const getClassnamesFromCSS = require('../util/cssFiles');
 // messageId will still be usable in tests.
 const CUSTOM_CLASSNAME_DETECTED_MSG = `Classname '{{classname}}' is not a Tailwind CSS class!`;
 
+const VALIDATION_TRIGGER_COMMENT = 'eslint-enable-next-line tailwindcss/no-custom-classname';
+
 module.exports = {
   meta: {
     docs: {
@@ -129,7 +131,24 @@ module.exports = {
       astUtil.parseNodeRecursive(node, null, parseForCustomClassNames);
     };
 
+    const programVisitor = function (node) {
+      const comments = node.comments;
+      for (const comment of comments) {
+        if (comment.type === 'Line' && comment.value.trim() === VALIDATION_TRIGGER_COMMENT) {
+          const nextToken = context.getTokenAfter(comment);
+          if (nextToken) {
+            const nextNode = context.getNodeByRangeIndex(nextToken.range[0]);
+            if (nextNode.type === 'VariableDeclaration') {
+              const init = nextNode.declarations[0].init;
+              return astUtil.parseNodeRecursive(nextNode, init, parseForCustomClassNames);
+            }
+          }
+        }
+      }
+    };
+
     const scriptVisitor = {
+      Program: programVisitor,
       JSXAttribute: attributeVisitor,
       TextAttribute: attributeVisitor,
       CallExpression: function (node) {

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -216,6 +216,9 @@ function parseNodeRecursive(node, arg, cb, skipConditional = false, isolate = fa
         trim = true;
         originalClassNamesValue = arg.value;
         break;
+      case 'Identifier':
+        parseNodeRecursive(node, arg.parent.value, cb, skipConditional, forceIsolation);
+        break;
       case 'TemplateElement':
         originalClassNamesValue = arg.value.raw;
         break;

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -608,6 +608,87 @@ ruleTester.run("no-custom-classname", rule, {
       code: `
       <div class="-ml-[1px] mr-[-1px]">Negative arbitrary value</div>`,
     },
+    {
+      code: `
+        // eslint-enable-next-line tailwindcss/no-custom-classname
+        const styles = 'p-2'
+      `,
+    },
+    {
+      code: `
+        // eslint-enable-next-line tailwindcss/no-custom-classname
+        const styles = ['p-2', 'm-2']
+      `,
+    },
+    {
+      code: `
+        // eslint-enable-next-line tailwindcss/no-custom-classname
+        const styles = clsx(['p-2', 'm-2']);
+      `,
+    },
+    {
+      code: `
+        // eslint-enable-next-line tailwindcss/no-custom-classname
+        const styles = {
+          primary: 'p-4',
+          secondary: ['p-2', 'm-2'],
+        }
+      `,
+    },
+    {
+      code: `
+        // eslint-enable-next-line tailwindcss/no-custom-classname
+        const styles = 'p-2 text-my-custom'
+      `,
+      options: [
+        {
+          config: {
+            theme: {
+              colors: {
+                "my-custom": "#B4D4AA",
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        // eslint-enable-next-line tailwindcss/no-custom-classname
+        const styles = ['p-2', 'm-2', 'text-my-custom']
+      `,
+      options: [
+        {
+          config: {
+            theme: {
+              colors: {
+                "my-custom": "#B4D4AA",
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        // eslint-enable-next-line tailwindcss/no-custom-classname
+        const styles = {
+          primary: 'p-4 text-my-custom',
+          secondary: ['p-2', 'm-2', 'text-my-custom'],
+        }
+      `,
+      options: [
+        {
+          config: {
+            theme: {
+              colors: {
+                "my-custom": "#B4D4AA",
+              },
+            },
+          },
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -844,6 +925,40 @@ ruleTester.run("no-custom-classname", rule, {
         },
       ],
       errors: generateErrors("xl:z-666"),
+    },
+    {
+      code: `
+        // eslint-enable-next-line tailwindcss/no-custom-classname
+        const styles = 'p-2 my-custom'
+      `,
+      errors: generateErrors("my-custom"),
+    },
+    {
+      code: `
+        // eslint-enable-next-line tailwindcss/no-custom-classname
+        const styles = ['p-2', 'm-2', 'my-custom']
+      `,
+      errors: generateErrors("my-custom"),
+    },
+    {
+      code: `
+        // eslint-enable-next-line tailwindcss/no-custom-classname
+        const styles = {
+          primary: 'p-4',
+          secondary: ['p-2', 'm-2', 'my-custom'],
+        }
+      `,
+      errors: generateErrors("my-custom"),
+    },
+    {
+      code: `
+        // eslint-enable-next-line tailwindcss/no-custom-classname
+        const styles = {
+          primary: 'p-4 my-custom',
+          secondary: ['p-2', 'm-2'],
+        }
+      `,
+      errors: generateErrors("my-custom"),
     },
   ],
 });


### PR DESCRIPTION
# Lint variables

## Description

In some cases, the developer might want to validate additional variables against proper class names. Let's say we want to create variants for our component.

```
const varianst = {
  primary: 'text-red-400 font-bold'
  secondary: 'text-blue-400'
}
```

The problem is that we can't be sure if provided classes are correct.  My idea is simple. User can enable this plugin against any variable by adding special comment:

```
// eslint-enable-next-line tailwindcss/no-custom-classname
```

For example:

```js
// eslint-enable-next-line tailwindcss/no-custom-classname
const styles = "p-2 text-blue-500";

// eslint-enable-next-line tailwindcss/no-custom-classname
const styles = ["p-2",  "text-blue-500"];

// eslint-enable-next-line tailwindcss/no-custom-classname
const variants = {
  primary: "p-5", 
  secondary: ["p-2",  "text-blue-500"],
  fancy: clsx(["px-10", "py-2"])
}
```


## Type of change

New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I've introduced new tests in `tests\lib\rules\no-custom-classname.js`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
