### PR TITLE
#136: Speed up execution time with caches

### DIFF
--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -22,6 +22,8 @@ const createContextFallback = require('tailwindcss/lib/lib/setupContextUtils').c
 // messageId will still be usable in tests.
 const INVALID_CLASSNAMES_ORDER_MSG = 'Invalid Tailwind CSS classnames order';
 
+const contextFallbackCache = new WeakMap();
+
 module.exports = {
   meta: {
     docs: {
@@ -88,7 +90,14 @@ module.exports = {
     const removeDuplicates = getOption(context, 'removeDuplicates');
 
     const mergedConfig = customConfig.resolve(twConfig);
-    const contextFallback = officialSorting ? createContextFallback(mergedConfig) : null;
+    const contextFallback = officialSorting
+      ? (
+          // Set the created contextFallback in the cache if it does not exist yet.
+          contextFallbackCache.has(mergedConfig)
+            ? contextFallbackCache
+            : contextFallbackCache.set(mergedConfig, createContextFallback(mergedConfig))
+        ).get(mergedConfig)
+      : null;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/lib/util/groupMethods.js
+++ b/lib/util/groupMethods.js
@@ -261,14 +261,23 @@ function generateOptions(propName, keys, config, isNegative = false) {
   }
 }
 
+const cachedRegexes = new WeakMap();
+
 /**
  * Customize the regex based on config
  *
  * @param {String} re Regular expression
  * @param {Object} config The merged Tailwind CSS config
- * @returns {String} Patched version with config values and additinal parameters
+ * @returns {String} Patched version with config values and additional parameters
  */
 function patchRegex(re, config) {
+  if (!cachedRegexes.has(config)) {
+    cachedRegexes.set(config, {});
+  }
+  const cache = cachedRegexes.get(config);
+  if (re in cache) {
+    return cache[re];
+  }
   let patched = '\\!?';
   // Prefix
   if (config.prefix.length) {
@@ -281,7 +290,7 @@ function patchRegex(re, config) {
   const resArray = [...res];
   const props = resArray.map((arr) => arr[1]);
   if (props.length === 0) {
-    return `${patched}(${replaced})`;
+    return cache[re] = `${patched}(${replaced})`;
   }
   // e.g. backgroundColor, letterSpacing, -margin...
   props.forEach((prop) => {
@@ -336,7 +345,7 @@ function patchRegex(re, config) {
     const opts = generateOptions(absoluteProp, keys, config, isNegative);
     replaced = replaced.replace(token, opts);
   });
-  return `${patched}(${replaced})`;
+  return cache[re] = `${patched}(${replaced})`;
 }
 
 /**


### PR DESCRIPTION
# #136: Speed up execution time with caches

## Description

This PR speeds up `tailwindcss/enforces-shorthand` and `tailwindcss/classnames-order` with `officialSorting: true` by introducing `WeakMap` caches to reduce duplicate calculations.

Since I cannot test this on @ronny1020's code base, I'm not sure if #136 can be marked as fixed with this PR. In particular, I also tried finding low-hanging fruit to optimise `tailwindcss/classnames-order` with `officialSorting: false`, but I couldn't find anything that would significantly speed things up.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've timed the `tailwindcss/*` rules using a minimal `.eslintrc` file on my code base (which I can't share, unfortunately).
```
$ TIMING=1 node --inspect ./node_modules/.bin/eslint .
$ time node --inspect ./node_modules/.bin/eslint .
```
Full details on the results of the timings can be found in the commit messages of 33d513af1d9986505d2f5320d13ea0c677690800 and 487121afb23e22d67f7665cd4292f8621934c261.

**Test Configuration**:
* OS + version: Arch Linux (last upgraded two weeks ago)
* NPM version: 8.5.5
* Node version: 16.15.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~New and~~ existing unit tests pass locally with my changes
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~
- [x] I have checked my code and corrected any misspellings