### PR TITLE
Fix #127: Don't ignore removeDuplicates option when using officialSorting

### DIFF
--- a/docs/rules/classnames-order.md
+++ b/docs/rules/classnames-order.md
@@ -118,7 +118,7 @@ const customGroups = require('custom-groups').groups;
 
 ### `officialSorting` (default: `false`)
 
-Set `officialSorting` to `true` if you want to use the same ordering rules as the official plugin `prettier-plugin-tailwindcss`. Enabling this settings will cause `groupByResponsive`, `groups`, `prependCustom` and `removeDuplicates` options to be ignored.
+Set `officialSorting` to `true` if you want to use the same ordering rules as the official plugin `prettier-plugin-tailwindcss`. Enabling this setting will cause `groupByResponsive`, `groups`, and `prependCustom` options to be ignored.
 
 ### `prependCustom` (default: `false`)
 

--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -314,20 +314,11 @@ module.exports = {
       }
 
       let orderedClassNames;
-      let validatedClassNamesValue = '';
 
+      // Sorting
       if (officialSorting) {
         orderedClassNames = order(classNames, contextFallback);
-        for (let i = 0; i < orderedClassNames.length; i++) {
-          const w = whitespaces[i] ?? '';
-          const cls = orderedClassNames[i];
-          validatedClassNamesValue += headSpace ? `${w}${cls}` : `${cls}${w}`;
-          if (headSpace && tailSpace && i === orderedClassNames.length - 1) {
-            validatedClassNamesValue += whitespaces[whitespaces.length - 1] ?? '';
-          }
-        }
       } else {
-        // Sorting
         const mergedSorted = [];
         const mergedExtras = [];
         if (groupByResponsive) {
@@ -343,18 +334,21 @@ module.exports = {
           mergedExtras.push(...extras);
         }
 
-        // Generates the validated/sorted attribute value
         const flatted = mergedSorted.flat();
-        const union = prependCustom ? [...mergedExtras, ...flatted] : [...flatted, ...mergedExtras];
-        for (let i = 0; i < union.length; i++) {
-          const w = whitespaces[i] ?? '';
-          const cls = union[i];
-          validatedClassNamesValue += headSpace ? `${w}${cls}` : `${cls}${w}`;
-          if (headSpace && tailSpace && i === union.length - 1) {
-            validatedClassNamesValue += whitespaces[whitespaces.length - 1] ?? '';
-          }
+        orderedClassNames = prependCustom ? [...mergedExtras, ...flatted] : [...flatted, ...mergedExtras];
+      }
+
+      // Generates the validated/sorted attribute value
+      let validatedClassNamesValue = '';
+      for (let i = 0; i < orderedClassNames.length; i++) {
+        const w = whitespaces[i] ?? '';
+        const cls = orderedClassNames[i];
+        validatedClassNamesValue += headSpace ? `${w}${cls}` : `${cls}${w}`;
+        if (headSpace && tailSpace && i === orderedClassNames.length - 1) {
+          validatedClassNamesValue += whitespaces[whitespaces.length - 1] ?? '';
         }
       }
+
       if (originalClassNamesValue !== validatedClassNamesValue) {
         validatedClassNamesValue = prefix + validatedClassNamesValue + suffix;
         context.report({

--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -309,6 +309,10 @@ module.exports = {
         return;
       }
 
+      if (removeDuplicates) {
+        removeDuplicatesFromClassnamesAndWhitespaces(classNames, whitespaces, headSpace, tailSpace);
+      }
+
       let orderedClassNames;
       let validatedClassNamesValue = '';
 
@@ -323,10 +327,6 @@ module.exports = {
           }
         }
       } else {
-        if (removeDuplicates) {
-          removeDuplicatesFromClassnamesAndWhitespaces(classNames, whitespaces, headSpace, tailSpace);
-        }
-
         // Sorting
         const mergedSorted = [];
         const mergedExtras = [];

--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -309,10 +309,6 @@ module.exports = {
         return;
       }
 
-      if (removeDuplicates) {
-        removeDuplicatesFromClassnamesAndWhitespaces(classNames, whitespaces, headSpace, tailSpace);
-      }
-
       let orderedClassNames;
 
       // Sorting
@@ -336,6 +332,10 @@ module.exports = {
 
         const flatted = mergedSorted.flat();
         orderedClassNames = prependCustom ? [...mergedExtras, ...flatted] : [...flatted, ...mergedExtras];
+      }
+
+      if (removeDuplicates) {
+        removeDuplicatesFromClassnamesAndWhitespaces(orderedClassNames, whitespaces, headSpace, tailSpace);
       }
 
       // Generates the validated/sorted attribute value

--- a/lib/util/removeDuplicatesFromClassnamesAndWhitespaces.js
+++ b/lib/util/removeDuplicatesFromClassnamesAndWhitespaces.js
@@ -1,20 +1,18 @@
 'use strict';
 
-function removeDuplicatesFromClassnamesAndWhitespaces(classNames, whitespaces, headSpace, tailSpace) {
-  const uniqueSet = new Set(classNames);
-  if (uniqueSet.size === classNames.length) {
-    return;
-  }
+function removeDuplicatesFromClassnamesAndWhitespaces(orderedClassNames, whitespaces, headSpace, tailSpace) {
+  let previous = orderedClassNames[0];
   const offset = (!headSpace && !tailSpace) || tailSpace ? -1 : 0;
-  uniqueSet.forEach((cls) => {
-    let duplicatedInstances = classNames.filter((el) => el === cls).length - 1;
-    while (duplicatedInstances > 0) {
-      const idx = classNames.lastIndexOf(cls);
-      classNames.splice(idx, 1);
-      whitespaces.splice(idx + offset, 1);
-      duplicatedInstances--;
+  for (let i = 1; i < orderedClassNames.length; i++) {
+    const cls = orderedClassNames[i];
+    // This function assumes that the list of classNames is ordered, so just comparing to the previous className is enough
+    if (cls === previous) {
+      orderedClassNames.splice(i, 1);
+      whitespaces.splice(i + offset, 1);
+      i--;
     }
-  });
+    previous = cls;
+  }
 }
 
 module.exports = removeDuplicatesFromClassnamesAndWhitespaces;

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -382,17 +382,17 @@ ruleTester.run("classnames-order", rule, {
     },
     {
       code: `<div class="w-12  lg:w-6   w-12">Single line dups + no head/tail spaces</div>`,
-      output: `<div class="w-12  lg:w-6">Single line dups + no head/tail spaces</div>`,
+      output: `<div class="w-12   lg:w-6">Single line dups + no head/tail spaces</div>`,
       errors: errors,
     },
     {
       code: `<div class=" w-12  lg:w-6   w-12">Single dups line + head spaces</div>`,
-      output: `<div class=" w-12  lg:w-6">Single dups line + head spaces</div>`,
+      output: `<div class=" w-12   lg:w-6">Single dups line + head spaces</div>`,
       errors: errors,
     },
     {
       code: `<div class="w-12  lg:w-6   w-12 ">Single line dups + tail spaces</div>`,
-      output: `<div class="w-12  lg:w-6 ">Single line dups + tail spaces</div>`,
+      output: `<div class="w-12   lg:w-6 ">Single line dups + tail spaces</div>`,
       errors: errors,
     },
     {

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -818,6 +818,16 @@ ruleTester.run("classnames-order", rule, {
       ],
     },
     {
+      code: `<div class="h-4 h-4 w-4">Using official sorting, with duplicates</div>`,
+      output: `<div class="h-4 w-4">Using official sorting, with duplicates</div>`,
+      errors: errors,
+      options: [
+        {
+          officialSorting: true,
+        },
+      ],
+    },
+    {
       code: `ctl(\`\${some} container animate-spin first:flex \${bool ? "flex-col flex" : ""}\`)`,
       output: `ctl(\`\${some} container animate-spin first:flex \${bool ? "flex flex-col" : ""}\`)`,
       errors: errors,


### PR DESCRIPTION
# Pull Request Name

## Description

The check for removing duplicates is completely separate from the sorting, even when `{officialSorting: false}`. Therefore, it shouldn't harm to also execute this check when `{officialSorting: true}`.

Fixes #127

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I've added the following test: `<div class="h-4 h-4 w-4">Using official sorting, with duplicates</div>` with config `{officialSorting: true}` (`removeDuplicates` is `true` by default).

**Test Configuration**:
* OS + version: Arch Linux (last upgraded today)
* NPM version: 8.5.5
* Node version: 16.15.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~
- [x] I have checked my code and corrected any misspellings

