### PR TITLE
FIX: Conflicting rules with ambiguous arbitrary values

### DIFF
--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -89,13 +89,18 @@ module.exports = {
       classNames = sorted.filter((slot) => slot.length > 1);
 
       // Sorts each groups' classnames
+      const ambiguousArbitraryValues = String.raw`(\[(.*${mergedConfig.separator}))`
+      const ambiguousArbitraryValuesOrClasses = String.raw`(\[(.*${mergedConfig.separator}))|(^((?!:).)*$)`
+      const arbitraryRegex = new RegExp(ambiguousArbitraryValues);
+
       classNames.forEach((slot) => {
         const variants = [];
         slot.forEach((cls) => {
-          const start = cls.lastIndexOf(mergedConfig.separator) + 1;
+          const arbiratySeparator = arbitraryRegex.test(cls);
+          const start = arbiratySeparator? 0 : cls.lastIndexOf(mergedConfig.separator) + 1;
           const prefix = cls.substr(0, start);
           const name = cls.substr(start);
-          const rePrefix = prefix === '' ? '((?!:).)*$' : prefix;
+          const rePrefix = prefix === '' ? ambiguousArbitraryValuesOrClasses : '^' + prefix;
           const idx = variants.findIndex((v) => v.prefix === rePrefix);
           if (idx === -1) {
             variants.push({
@@ -109,7 +114,7 @@ module.exports = {
         const troubles = variants.filter((v) => v.name.length > 1);
         if (troubles.length) {
           troubles.forEach((issue) => {
-            const re = new RegExp('^' + issue.prefix);
+            const re = new RegExp(issue.prefix);
             const conflicting = slot.filter((c) => re.test(c));
             context.report({
               node: node,

--- a/tests/lib/rules/no-contradicting-classname.js
+++ b/tests/lib/rules/no-contradicting-classname.js
@@ -172,6 +172,12 @@ ruleTester.run("no-contradicting-classname", rule, {
     },
     {
       code: `
+      <div class="text-left text-lg text-[color:var(--my-var,#ccc)]]">
+        Same class prefix, type prefix may be required for resolving ambiguous values
+      </div>`,
+    },
+    {
+      code: `
       <div class="scale-75 translate-x-4 skew-y-3 motion-reduce:transform-none">
         Legit transform-none
       </div>`,
@@ -243,11 +249,11 @@ ruleTester.run("no-contradicting-classname", rule, {
       export interface FakePropsInterface {
         readonly name?: string;
       }
-      
+
       function Fake({
         name = 'yolo'
       }: FakeProps) {
-      
+
         return (
           <>
             <h1 className={"container w-1 w-2"}>Welcome {name}</h1>
@@ -255,7 +261,7 @@ ruleTester.run("no-contradicting-classname", rule, {
           </>
         );
       }
-      
+
       export default Fake;
       `,
       parser: require.resolve("@typescript-eslint/parser"),
@@ -451,6 +457,30 @@ ruleTester.run("no-contradicting-classname", rule, {
       `,
       options: config,
       errors: generateErrors("rounded-xl rounded-[50%/10%] rounded-[10%,30%,50%,70%] rounded-[var(--some)]"),
+    },
+    {
+      code: `
+      <div class="text-white text-[color:var(--my-var,#ccc)]">
+        Arbitrary values for text color
+      </div>
+      `,
+      errors: generateErrors("text-white text-[color:var(--my-var,#ccc)]"),
+    },
+    {
+      code: `
+      <div class="text-lg text-[length:var(--my-var)]">
+        Arbitrary values for text font size
+      </div>
+      `,
+      errors: generateErrors("text-lg text-[length:var(--my-var)]"),
+    },
+    {
+      code: `
+      <div class="bg-white bg-[color:var(--donno)]">
+        Arbitrary values for background color
+      </div>
+      `,
+      errors: generateErrors("bg-white bg-[color:var(--donno)]"),
     },
     {
       code: `<div class="aspect-none aspect-w-16 aspect-w-10 aspect-h-9">aspect</div>`,


### PR DESCRIPTION
FIX: Conflicting rules with arbitrary values

## Description

This changes the algorithm on the rule `lib/rules/no-contradicting-classname.js`, to detect conflicting rules when using ambiguous arbitrary values.


Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I've added a test to tests/lib/rules/no-contradicting-classname.js.

**Test Configuration**:
* OS + version: macOS monterey
* NPM version: 6.14.11
* Node version: v14.16.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
