### PR TITLE
Prevent rule crash from class/className shorthand while typing.

### DIFF
--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -204,7 +204,7 @@ module.exports = {
       }
       if (astUtil.isLiteralAttributeValue(node)) {
         sortNodeArgumentValue(node);
-      } else if (node.value.type === 'JSXExpressionContainer') {
+      } else if (node.value && node.value.type === 'JSXExpressionContainer') {
         sortNodeArgumentValue(node, node.value.expression);
       }
     };

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -147,7 +147,7 @@ module.exports = {
       }
       if (astUtil.isLiteralAttributeValue(node)) {
         parseForNegativeArbitraryClassNames(node);
-      } else if (node.value.type === 'JSXExpressionContainer') {
+      } else if (node.value && node.value.type === 'JSXExpressionContainer') {
         parseForNegativeArbitraryClassNames(node, node.value.expression);
       }
     };

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -375,7 +375,7 @@ module.exports = {
       }
       if (astUtil.isLiteralAttributeValue(node)) {
         parseForShorthandCandidates(node);
-      } else if (node.value.type === 'JSXExpressionContainer') {
+      } else if (node.value && node.value.type === 'JSXExpressionContainer') {
         parseForShorthandCandidates(node, node.value.expression);
       }
     };

--- a/lib/rules/migration-from-tailwind-2.js
+++ b/lib/rules/migration-from-tailwind-2.js
@@ -260,7 +260,7 @@ module.exports = {
       }
       if (astUtil.isLiteralAttributeValue(node)) {
         parseForObsoleteClassNames(node);
-      } else if (node.value.type === 'JSXExpressionContainer') {
+      } else if (node.value && node.value.type === 'JSXExpressionContainer') {
         parseForObsoleteClassNames(node, node.value.expression);
       }
     };

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -146,7 +146,7 @@ module.exports = {
       }
       if (astUtil.isLiteralAttributeValue(node)) {
         parseForArbitraryValues(node);
-      } else if (node.value.type === 'JSXExpressionContainer') {
+      } else if (node.value && node.value.type === 'JSXExpressionContainer') {
         parseForArbitraryValues(node, node.value.expression);
       }
     };

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -133,7 +133,7 @@ module.exports = {
       }
       if (astUtil.isLiteralAttributeValue(node)) {
         astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true);
-      } else if (node.value.type === 'JSXExpressionContainer') {
+      } else if (node.value && node.value.type === 'JSXExpressionContainer') {
         astUtil.parseNodeRecursive(node, node.value.expression, parseForContradictingClassNames, true);
       }
     };

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -142,7 +142,7 @@ module.exports = {
       }
       if (astUtil.isLiteralAttributeValue(node)) {
         astUtil.parseNodeRecursive(node, null, parseForCustomClassNames);
-      } else if (node.value.type === 'JSXExpressionContainer') {
+      } else if (node.value && node.value.type === 'JSXExpressionContainer') {
         astUtil.parseNodeRecursive(node, node.value.expression, parseForCustomClassNames);
       }
     };

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -241,6 +241,9 @@ ruleTester.run("classnames-order", rule, {
       </div>
       `,
     },
+    {
+      code: `<div class>No errors while typing</div>`,
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/enforces-negative-arbitrary-values.js
+++ b/tests/lib/rules/enforces-negative-arbitrary-values.js
@@ -49,6 +49,9 @@ ruleTester.run("enforces-negative-arbitrary-values", rule, {
     {
       code: `<div className={\`top-[-50px]\`}>top-[-50px]</div>`,
     },
+    {
+      code: `<div className>No errors while typing</div>`,
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/enforces-shorthand.js
+++ b/tests/lib/rules/enforces-shorthand.js
@@ -86,6 +86,9 @@ ruleTester.run("shorthands", rule, {
     {
       code: `<div className="py-2.5 md:py-3 pl-2.5 md:pl-4 font-medium uppercase">issue #91</div>`,
     },
+    {
+      code: `<div class>No errors while typing</div>`,
+    },
   ],
 
   invalid: [

--- a/tests/lib/rules/migration-from-tailwind-2.js
+++ b/tests/lib/rules/migration-from-tailwind-2.js
@@ -36,6 +36,9 @@ ruleTester.run("migration-from-tailwind-2", rule, {
     {
       code: `<div class="transition-[var(--transform)]">transition-[var(--transform)]</div>`,
     },
+    {
+      code: `<div class>No errors while typing</div>`,
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-arbitrary-value.js
+++ b/tests/lib/rules/no-arbitrary-value.js
@@ -46,6 +46,9 @@ ruleTester.run("no-arbitrary-value", rule, {
     {
       code: `<div class="flex shrink-0 flex-col">No arbitrary value</div>`,
     },
+    {
+      code: `<div class>No errors while typing</div>`,
+    },
   ],
 
   invalid: [

--- a/tests/lib/rules/no-contradicting-classname.js
+++ b/tests/lib/rules/no-contradicting-classname.js
@@ -235,6 +235,9 @@ ruleTester.run("no-contradicting-classname", rule, {
         },
       ],
     },
+    {
+      code: "<div class>No errors while typing</div>",
+    },
   ],
 
   invalid: [

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -791,6 +791,9 @@ ruleTester.run("no-custom-classname", rule, {
         border-spacing
       </div>`,
     },
+    {
+      code: `<div class>No errors while typing</div>`,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
# Pull Request Name

## Description

Prevent `<div class></div>` from crashing.

Fixes #157

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

tests/lib/rules/classnames-order.js
tests/lib/rules/enforces-negative-arbitrary-values.js
tests/lib/rules/enforces-shorthand.js
tests/lib/rules/migration-from-tailwind-2.js
tests/lib/rules/no-arbitrary-value.js
tests/lib/rules/no-contradicting-classname.js
tests/lib/rules/no-custom-classname.js

**Test Configuration**:
* macOS Monterey
* npm 8.5.5
* node v16.14.2

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
