### PR TITLE
Add support for custom classRegex option in addition to class and className

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ All these settings have nice default values that are explained in each rules' do
       cssFilesRefreshRate: 5_000,
       removeDuplicates: true,
       whitelist: [],
+      tags: [],
+      classRegex: "^class(Name)?$" // can be modified to support custom attributes. E.g. "^tw$" for `twin.macro`
     },
   },
 }

--- a/docs/rules/classnames-order.md
+++ b/docs/rules/classnames-order.md
@@ -58,3 +58,7 @@ Duplicate classnames are automatically removed but you can always disable this b
 ### `tags` (default: `[]`)
 
 Optional, if you are using tagged templates, you should provide the tags in this array.
+
+### `classRegex` (default: `"^class(Name)?$"`)
+
+Optional, can be used to support custom attribues

--- a/docs/rules/enforces-negative-arbitrary-values.md
+++ b/docs/rules/enforces-negative-arbitrary-values.md
@@ -72,3 +72,7 @@ Finally, the plugin will [merge the provided configuration](https://tailwindcss.
 ### `tags` (default: `[]`)
 
 Optional, if you are using tagged templates, you should provide the tags in this array.
+
+### `classRegex` (default: `"^class(Name)?$"`)
+
+Optional, can be used to support custom attribues

--- a/docs/rules/enforces-shorthand.md
+++ b/docs/rules/enforces-shorthand.md
@@ -65,6 +65,10 @@ Finally, the plugin will [merge the provided configuration](https://tailwindcss.
 
 Optional, if you are using tagged templates, you should provide the tags in this array.
 
+### `classRegex` (default: `"^class(Name)?$"`)
+
+Optional, can be used to support custom attribues
+
 ## Further Reading
 
 This rule will fix the issue for you.

--- a/docs/rules/migration-from-tailwind-2.md
+++ b/docs/rules/migration-from-tailwind-2.md
@@ -109,3 +109,7 @@ Finally, the plugin will [merge the provided configuration](https://tailwindcss.
 ### `tags` (default: `[]`)
 
 Optional, if you are using tagged templates, you should provide the tags in this array.
+
+### `classRegex` (default: `"^class(Name)?$"`)
+
+Optional, can be used to support custom attribues

--- a/docs/rules/no-arbitrary-value.md
+++ b/docs/rules/no-arbitrary-value.md
@@ -55,6 +55,10 @@ Finally, the plugin will [merge the provided configuration](https://tailwindcss.
 
 Optional, if you are using tagged templates, you should provide the tags in this array.
 
+### `classRegex` (default: `"^class(Name)?$"`)
+
+Optional, can be used to support custom attribues
+
 ## Further Reading
 
 This rule will not fix the issue for you because it cannot guess the correct class candidate.

--- a/docs/rules/no-contradicting-classname.md
+++ b/docs/rules/no-contradicting-classname.md
@@ -55,6 +55,10 @@ Finally, the plugin will [merge the provided configuration](https://tailwindcss.
 
 Optional, if you are using tagged templates, you should provide the tags in this array.
 
+### `classRegex` (default: `"^class(Name)?$"`)
+
+Optional, can be used to support custom attribues
+
 ## Further Reading
 
 This rule will not fix the issue but will let you know about the issue.

--- a/docs/rules/no-custom-classname.md
+++ b/docs/rules/no-custom-classname.md
@@ -83,6 +83,10 @@ The `whitelist` options should be set to:
 - or if you don't like regular expressions (but you should):
   `['skin\\-summer', 'skin\\-xmas', 'custom\\-1', 'custom\\-2', 'custom\\-3']`
 
+### `classRegex` (default: `"^class(Name)?$"`)
+
+Optional, can be used to support custom attribues
+
 ## Further Reading
 
 This rule will not fix the issue but will let you know about the issue.

--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -68,6 +68,7 @@ module.exports = {
     const callees = getOption(context, 'callees');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
+    const classRegex = getOption(context, 'classRegex');
     const groupsConfig = groups;
     const removeDuplicates = getOption(context, 'removeDuplicates');
 
@@ -199,7 +200,7 @@ module.exports = {
     //----------------------------------------------------------------------
 
     const attributeVisitor = function (node) {
-      if (!astUtil.isClassAttribute(node)) {
+      if (!astUtil.isClassAttribute(node, classRegex)) {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -59,6 +59,7 @@ module.exports = {
     const callees = getOption(context, 'callees');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
+    const classRegex = getOption(context, 'classRegex');
 
     const mergedConfig = customConfig.resolve(twConfig);
 
@@ -142,7 +143,7 @@ module.exports = {
     //----------------------------------------------------------------------
 
     const attributeVisitor = function (node) {
-      if (!astUtil.isClassAttribute(node)) {
+      if (!astUtil.isClassAttribute(node, classRegex)) {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -59,6 +59,7 @@ module.exports = {
     const callees = getOption(context, 'callees');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
+    const classRegex = getOption(context, 'classRegex');
 
     const mergedConfig = customConfig.resolve(twConfig);
 
@@ -370,7 +371,7 @@ module.exports = {
     //----------------------------------------------------------------------
 
     const attributeVisitor = function (node) {
-      if (!astUtil.isClassAttribute(node)) {
+      if (!astUtil.isClassAttribute(node, classRegex)) {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {

--- a/lib/rules/migration-from-tailwind-2.js
+++ b/lib/rules/migration-from-tailwind-2.js
@@ -64,6 +64,7 @@ module.exports = {
     const callees = getOption(context, 'callees');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
+    const classRegex = getOption(context, 'classRegex');
 
     const mergedConfig = customConfig.resolve(twConfig);
 
@@ -255,7 +256,7 @@ module.exports = {
     //----------------------------------------------------------------------
 
     const attributeVisitor = function (node) {
-      if (!astUtil.isClassAttribute(node)) {
+      if (!astUtil.isClassAttribute(node, classRegex)) {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -58,6 +58,7 @@ module.exports = {
     const callees = getOption(context, 'callees');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
+    const classRegex = getOption(context, 'classRegex');
 
     const mergedConfig = customConfig.resolve(twConfig);
 
@@ -141,7 +142,7 @@ module.exports = {
     //----------------------------------------------------------------------
 
     const attributeVisitor = function (node) {
-      if (!astUtil.isClassAttribute(node)) {
+      if (!astUtil.isClassAttribute(node, classRegex)) {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -59,6 +59,7 @@ module.exports = {
     const callees = getOption(context, 'callees');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
+    const classRegex = getOption(context, 'classRegex');
 
     const mergedConfig = customConfig.resolve(twConfig);
 
@@ -133,7 +134,7 @@ module.exports = {
     //----------------------------------------------------------------------
 
     const attributeVisitor = function (node) {
-      if (!astUtil.isClassAttribute(node)) {
+      if (!astUtil.isClassAttribute(node, classRegex)) {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -81,6 +81,7 @@ module.exports = {
     const cssFiles = getOption(context, 'cssFiles');
     const cssFilesRefreshRate = getOption(context, 'cssFilesRefreshRate');
     const whitelist = getOption(context, 'whitelist');
+    const classRegex = getOption(context, 'classRegex');
 
     const mergedConfig = customConfig.resolve(twConfig);
     const contextFallback = // Set the created contextFallback in the cache if it does not exist yet.
@@ -137,7 +138,7 @@ module.exports = {
     //----------------------------------------------------------------------
 
     const attributeVisitor = function (node) {
-      if (!astUtil.isClassAttribute(node)) {
+      if (!astUtil.isClassAttribute(node, classRegex)) {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -14,9 +14,10 @@ const removeDuplicatesFromArray = require('./removeDuplicatesFromArray');
  * Find out if node is `class` or `className`
  *
  * @param {ASTNode} node The AST node being checked
+ * @param {String} classRegex Regex to test the attribute that is being checked against
  * @returns {Boolean}
  */
-function isClassAttribute(node) {
+function isClassAttribute(node, classRegex) {
   if (!node.name) {
     return false;
   }
@@ -28,7 +29,7 @@ function isClassAttribute(node) {
     default:
       name = node.name.name;
   }
-  return /^class(Name)?$|^tw$/.test(name);
+  return new RegExp(classRegex).test(name);
 }
 
 /**
@@ -81,10 +82,11 @@ function isLiteralAttributeValue(node) {
  * Find out if the node is a valid candidate for our rules
  *
  * @param {ASTNode} node The AST node being checked
+ * @param {String} classRegex Regex to test the attribute that is being checked against
  * @returns {Boolean}
  */
-function isValidJSXAttribute(node) {
-  if (!isClassAttribute(node)) {
+function isValidJSXAttribute(node, classRegex) {
+  if (!isClassAttribute(node, classRegex)) {
     // Only run for class[Name] attributes
     return false;
   }

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -28,7 +28,7 @@ function isClassAttribute(node) {
     default:
       name = node.name.name;
   }
-  return /^class(Name)?$/.test(name);
+  return /^class(Name)?$|^tw$/.test(name);
 }
 
 /**

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -24,6 +24,8 @@ function getOption(context, name) {
       return [];
     case 'whitelist':
       return [];
+    case 'classRegex':
+      return "^class(Name)?$"
   }
 }
 

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -66,6 +66,9 @@ ruleTester.run("classnames-order", rule, {
       code: `<div class="custom container box-content lg:box-border">Simple, basic</div>`,
     },
     {
+      code: `<div tw="custom container box-content lg:box-border">Simple, using 'tw' prop</div>`,
+    },
+    {
       code: "<div className={ctl(`w-full p-10 ${live && 'bg-blue-100 dark:bg-purple-400 sm:rounded-lg'}`)}>ctl + exp</div>",
     },
     {
@@ -90,6 +93,9 @@ ruleTester.run("classnames-order", rule, {
     },
     {
       code: `<div class="space-y-0.5 ">Extra space at the end</div>`,
+    },
+    {
+      code: `<div tw="space-y-0.5 ">Extra space at the end, but with 'tw' prop</div>`,
     },
     {
       code: `<div class="p-5 sm:px-3 md:py-2 lg:p-4 xl:px-6">'p', then 'py' then 'px'</div>`,
@@ -290,6 +296,11 @@ ruleTester.run("classnames-order", rule, {
     {
       code: `<div class="sm:py-5 p-4 sm:px-7 lg:p-8">Enhancing readability</div>`,
       output: `<div class="p-4 sm:py-5 sm:px-7 lg:p-8">Enhancing readability</div>`,
+      errors: errors,
+    },
+    {
+      code: `<div tw="sm:py-5 p-4 sm:px-7 lg:p-8">Enhancing readability with 'tw' prop</div>`,
+      output: `<div tw="p-4 sm:py-5 sm:px-7 lg:p-8">Enhancing readability with 'tw' prop</div>`,
       errors: errors,
     },
     {

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -67,6 +67,11 @@ ruleTester.run("classnames-order", rule, {
     },
     {
       code: `<div tw="custom container box-content lg:box-border">Simple, using 'tw' prop</div>`,
+      options: [
+        {
+          classRegex: "^tw$",
+        },
+      ],
     },
     {
       code: "<div className={ctl(`w-full p-10 ${live && 'bg-blue-100 dark:bg-purple-400 sm:rounded-lg'}`)}>ctl + exp</div>",
@@ -96,6 +101,11 @@ ruleTester.run("classnames-order", rule, {
     },
     {
       code: `<div tw="space-y-0.5 ">Extra space at the end, but with 'tw' prop</div>`,
+      options: [
+        {
+          classRegex: "^tw$",
+        },
+      ],
     },
     {
       code: `<div class="p-5 sm:px-3 md:py-2 lg:p-4 xl:px-6">'p', then 'py' then 'px'</div>`,
@@ -301,6 +311,11 @@ ruleTester.run("classnames-order", rule, {
     {
       code: `<div tw="sm:py-5 p-4 sm:px-7 lg:p-8">Enhancing readability with 'tw' prop</div>`,
       output: `<div tw="p-4 sm:py-5 sm:px-7 lg:p-8">Enhancing readability with 'tw' prop</div>`,
+      options: [
+        {
+          classRegex: "^tw$",
+        },
+      ],
       errors: errors,
     },
     {


### PR DESCRIPTION
# Pull Request Name

## Description

Adds a custom classRegex option in line with to support external libraries like [twin.macro](https://github.com/ben-rogerson/twin.macro). The option name is in line with the option of the [Official Tailwind CSS IntelliSense VSCode plugin](https://github.com/tailwindlabs/tailwindcss/issues/7553).

This PR was based on @finnmerlett earlier work.

```json5
{
  settings: {
    tailwindcss: {
      classRegex: "^class(Name)?$" // can be modified to support custom attributes. E.g. "^tw$" for `twin.macro`
    },
  },
}
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
