### PR TITLE
feat: Support for Object syntax in custom callees beside `classnames`

### DIFF
--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -126,8 +126,10 @@ module.exports = {
             });
             return;
           case 'ObjectExpression':
+            const isUsedByClassNamesPlugin = node.callee && node.callee.name === 'classnames';
+
             arg.properties.forEach((prop) => {
-              sortNodeArgumentValue(node, prop.key);
+              sortNodeArgumentValue(node, isUsedByClassNamesPlugin ? prop.key : prop.value);
             });
             return;
           case 'Literal':

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -101,8 +101,10 @@ module.exports = {
             });
             return;
           case 'ObjectExpression':
+            const isUsedByClassNamesPlugin = node.callee && node.callee.name === 'classnames';
+
             arg.properties.forEach((prop) => {
-              parseForNegativeArbitraryClassNames(node, prop.key);
+              parseForNegativeArbitraryClassNames(node, isUsedByClassNamesPlugin ? prop.key : prop.value);
             });
             return;
           case 'Literal':

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -153,8 +153,10 @@ module.exports = {
             });
             return;
           case 'ObjectExpression':
+            const isUsedByClassNamesPlugin = node.callee && node.callee.name === 'classnames';
+
             arg.properties.forEach((prop) => {
-              parseForShorthandCandidates(node, prop.key);
+              parseForShorthandCandidates(node, isUsedByClassNamesPlugin ? prop.key : prop.value);
             });
             return;
           case 'Literal':

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -100,8 +100,10 @@ module.exports = {
             });
             return;
           case 'ObjectExpression':
+            const isUsedByClassNamesPlugin = node.callee && node.callee.name === 'classnames';
+
             arg.properties.forEach((prop) => {
-              parseForArbitraryValues(node, prop.key);
+              parseForArbitraryValues(node, isUsedByClassNamesPlugin ? prop.key : prop.value);
             });
             return;
           case 'Literal':

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -209,7 +209,15 @@ function parseNodeRecursive(node, arg, cb, skipConditional = false, isolate = fa
         return;
       case 'ObjectExpression':
         arg.properties.forEach((prop) => {
-          parseNodeRecursive(node, prop.key, cb, skipConditional, forceIsolation);
+          const isUsedByClassNamesPlugin = node.callee && node.callee.name === 'classnames';
+
+          parseNodeRecursive(
+            node,
+            isUsedByClassNamesPlugin ? prop.key : prop.value,
+            cb,
+            skipConditional,
+            forceIsolation
+          );
         });
         return;
       case 'Literal':

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -492,6 +492,20 @@ ruleTester.run("classnames-order", rule, {
       errors: errors,
     },
     {
+      code: `cva({
+          primary: ["absolute bottom-0 w-full h-[70px] flex flex-col"],
+        })`,
+      output: `cva({
+          primary: ["absolute bottom-0 flex h-[70px] w-full flex-col"],
+        })`,
+      options: [
+        {
+          callees: ["cva"],
+        },
+      ],
+      errors: errors,
+    },
+    {
       code: `<div className={clsx(\`absolute bottom-0 w-full h-[270px] flex flex-col\`)}>clsx</div>`,
       output: `<div className={clsx(\`absolute bottom-0 flex h-[270px] w-full flex-col\`)}>clsx</div>`,
       options: [

--- a/tests/lib/rules/enforces-shorthand.js
+++ b/tests/lib/rules/enforces-shorthand.js
@@ -465,5 +465,19 @@ ruleTester.run("shorthands", rule, {
       `,
       errors: [generateError(["p-2", "pl-2", "pr-2"], "p-2")],
     },
+    {
+      code: `cva({
+          primary: ["border-l-0 border-r-0"],
+        });`,
+      output: `cva({
+          primary: ["border-x-0"],
+        });`,
+      options: [
+        {
+          callees: ["cva"],
+        },
+      ],
+      errors: [generateError(["border-l-0", "border-r-0"], "border-x-0")],
+    },
   ],
 });

--- a/tests/lib/rules/no-arbitrary-value.js
+++ b/tests/lib/rules/no-arbitrary-value.js
@@ -79,16 +79,11 @@ ruleTester.run("no-arbitrary-value", rule, {
     {
       code: `
       <nav
-        className={cns("flex relative flex-row rounded-lg select-none", {
+        className={classnames("flex relative flex-row rounded-lg select-none", {
           "bg-gray-200 p-1": !size,
           "bg-gray-100 p-[3px]": size === "sm",
         })}
       />`,
-      options: [
-        {
-          callees: ["cns"],
-        },
-      ],
       errors: generateErrors("p-[3px]"),
     },
     {
@@ -101,6 +96,18 @@ ruleTester.run("no-arbitrary-value", rule, {
         ]
       );`,
       errors: generateErrors("text-[length:var(--font-size)] rounded-[2em] p-[4vw] leading-[1]"),
+    },
+    {
+      code: `
+      cva({
+        primary: ["[mask-type:luminance] container flex bg-[rgba(10,20,30,0.5)] w-12 sm:w-6 lg:w-4"],
+      });`,
+      options: [
+        {
+          callees: ["cva"],
+        },
+      ],
+      errors: generateErrors("[mask-type:luminance] bg-[rgba(10,20,30,0.5)]"),
     },
   ],
 });

--- a/tests/lib/rules/no-contradicting-classname.js
+++ b/tests/lib/rules/no-contradicting-classname.js
@@ -608,6 +608,18 @@ ruleTester.run("no-contradicting-classname", rule, {
       </div>`,
       errors: generateErrors("-outline-offset-2 outline-offset-4"),
     },
+    {
+      code: `
+      cva({
+        primary: ["px-2 px-4"],
+      });`,
+      options: [
+        {
+          callees: ["cva"],
+        },
+      ],
+      errors: generateErrors(["px-2 px-4"]),
+    },
     // {
     //   code: `
     //   <div class="scale-75 transform-none">

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -67,20 +67,20 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <section>
-          <h1>Layout utilities</h1>
-          <div class="container">Container</div>
-          <div class="box-content lg:box-border">Box Sizing</div>
-          <div class="inline-block sm:block md:flex lg:table">Display</div>
-          <div class="float-none sm:float-left md:float-right">Floats</div>
-          <div class="clear-left sm:clear-right md:clear-both lg:clear-none">Clear</div>
-          <div class="isolate sm:isolation-auto">Isolation</div>
-          <div class="object-contain sm:object-cover md:object-fill lg:object-none dark:object-scale-down">Object Fit</div>
-          <div class="overflow-auto sm:overflow-scroll">Overflow</div>
-          <div class="overscroll-none md:overscroll-y-auto">Overscroll Behavior</div>
-          <div class="fixed sm:absolute">Position</div>
-          <div class="visible sm:invisible">Visibility</div>
-        </section>`,
+      <section>
+        <h1>Layout utilities</h1>
+        <div class="container">Container</div>
+        <div class="box-content lg:box-border">Box Sizing</div>
+        <div class="inline-block sm:block md:flex lg:table">Display</div>
+        <div class="float-none sm:float-left md:float-right">Floats</div>
+        <div class="clear-left sm:clear-right md:clear-both lg:clear-none">Clear</div>
+        <div class="isolate sm:isolation-auto">Isolation</div>
+        <div class="object-contain sm:object-cover md:object-fill lg:object-none dark:object-scale-down">Object Fit</div>
+        <div class="overflow-auto sm:overflow-scroll">Overflow</div>
+        <div class="overscroll-none md:overscroll-y-auto">Overscroll Behavior</div>
+        <div class="fixed sm:absolute">Position</div>
+        <div class="visible sm:invisible">Visibility</div>
+      </section>`,
     },
     {
       code: `<div class="columns-2 hover:columns-3 lg:columns-[10rem]">Columns</div>`,
@@ -117,230 +117,230 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <section>
-          <h1>Flexbox & Grid</h1>
-          <div class="basis-[14.2857143%] sm:basis-1">Flex Basis</div>
-          <div class="flex-row">Flex Direction</div>
-          <div class="flex-wrap">Flex Wrap</div>
-          <div class="flex-auto sm:flex-1 flex-[2_2_0%]">Flex</div>
-          <div class="grow sm:grow-0 md:grow-[2]">Flex Grow</div>
-          <div class="shrink sm:shrink-0 md:shrink-[2]">Flex Shrink</div>
-          <div class="order-1 sm:order-[13]">Order</div>
-          <div class="grid-cols-6 sm:grid-cols-[200px_minmax(900px,_1fr)_100px]"></div>
-          <div class="col-auto sm:col-span-1 md:col-[span_1_/_span_3]">Grid Column Start / End</div>
-          <div class="grid-rows-4 sm:grid-rows-[200px_minmax(900px,_1fr)_100px]">Grid Template Rows</div>
-          <div class="row-auto sm:row-span-6 md:row-span-full lg:row-[span_16_/_span_16]">Grid Row Start / End</div>
-          <div class="grid-flow-row-dense">Grid Auto Flow</div>
-          <div class="auto-cols-max sm:auto-cols-[minmax(0,_2fr)]">Grid Auto Columns</div>
-          <div class="auto-rows-max auto-rows-[minmax(0,_2fr)]">Grid Auto Rows</div>
-          <div class="gap-x-0 sm:gap-y-3 gap-[2.75rem]">Gap</div>
-          <div class="justify-end	">Justify Content</div>
-          <div class="justify-items-end	">Justify Items</div>
-          <div class="justify-self-start">Justify Self</div>
-          <div class="content-center">Align Content</div>
-          <div class="items-baseline">Align Items</div>
-          <div class="self-stretch">Align Self</div>
-          <div class="place-content-evenly">Place Content</div>
-          <div class="place-items-center">Place Items</div>
-          <div class="place-self-center">Place Self</div>
-        </section>`,
+      <section>
+        <h1>Flexbox & Grid</h1>
+        <div class="basis-[14.2857143%] sm:basis-1">Flex Basis</div>
+        <div class="flex-row">Flex Direction</div>
+        <div class="flex-wrap">Flex Wrap</div>
+        <div class="flex-auto sm:flex-1 flex-[2_2_0%]">Flex</div>
+        <div class="grow sm:grow-0 md:grow-[2]">Flex Grow</div>
+        <div class="shrink sm:shrink-0 md:shrink-[2]">Flex Shrink</div>
+        <div class="order-1 sm:order-[13]">Order</div>
+        <div class="grid-cols-6 sm:grid-cols-[200px_minmax(900px,_1fr)_100px]"></div>
+        <div class="col-auto sm:col-span-1 md:col-[span_1_/_span_3]">Grid Column Start / End</div>
+        <div class="grid-rows-4 sm:grid-rows-[200px_minmax(900px,_1fr)_100px]">Grid Template Rows</div>
+        <div class="row-auto sm:row-span-6 md:row-span-full lg:row-[span_16_/_span_16]">Grid Row Start / End</div>
+        <div class="grid-flow-row-dense">Grid Auto Flow</div>
+        <div class="auto-cols-max sm:auto-cols-[minmax(0,_2fr)]">Grid Auto Columns</div>
+        <div class="auto-rows-max auto-rows-[minmax(0,_2fr)]">Grid Auto Rows</div>
+        <div class="gap-x-0 sm:gap-y-3 gap-[2.75rem]">Gap</div>
+        <div class="justify-end	">Justify Content</div>
+        <div class="justify-items-end	">Justify Items</div>
+        <div class="justify-self-start">Justify Self</div>
+        <div class="content-center">Align Content</div>
+        <div class="items-baseline">Align Items</div>
+        <div class="self-stretch">Align Self</div>
+        <div class="place-content-evenly">Place Content</div>
+        <div class="place-items-center">Place Items</div>
+        <div class="place-self-center">Place Self</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Spacing</h1>
-          <div class="p-1 sm:pr-0 md:px-[5px]">Padding</div>
-          <div class="m-1 sm:mr-0 md:mx-[5px] lg:-ml-1">Margin</div>
-          <div class="space-x-0 sm:space-y-1 md:space-x-reverse lg:space-y-reverse xl:space-y-[5px] dark:-space-x-1 sm:dark:-space-y-1 xl:dark:space-y-[-5px]">Space Between</div>
-        </section>`,
+      <section>
+        <h1>Spacing</h1>
+        <div class="p-1 sm:pr-0 md:px-[5px]">Padding</div>
+        <div class="m-1 sm:mr-0 md:mx-[5px] lg:-ml-1">Margin</div>
+        <div class="space-x-0 sm:space-y-1 md:space-x-reverse lg:space-y-reverse xl:space-y-[5px] dark:-space-x-1 sm:dark:-space-y-1 xl:dark:space-y-[-5px]">Space Between</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Sizing</h1>
-          <div class="w-0 sm:w-px md:w-1/2 lg:w-max xl:w-[32rem]">Width</div>
-          <div class="min-w-0 sm:min-w-full md:min-w-min lg:min-w-max xl:min-w-[50%]">Min-Width</div>
-          <div class="max-w-0 sm:max-w-none md:max-w-2xl lg:max-w-screen-xl xl:max-w-[50%]">Max-Width</div>
-          <div class="h-0 sm:h-px md:h-1/2 lg:h-max xl:h-[32rem]">Height</div>
-          <div class="min-h-0 sm:min-h-full md:min-h-min lg:min-h-max xl:min-h-[50%]">Min-Height</div>
-          <div class="max-h-0 sm:max-h-2 md:max-h-full lg:max-h-screen xl:max-h-[32rem]">Max-Height</div>
-          <div class=""></div>
-        </section>`,
+      <section>
+        <h1>Sizing</h1>
+        <div class="w-0 sm:w-px md:w-1/2 lg:w-max xl:w-[32rem]">Width</div>
+        <div class="min-w-0 sm:min-w-full md:min-w-min lg:min-w-max xl:min-w-[50%]">Min-Width</div>
+        <div class="max-w-0 sm:max-w-none md:max-w-2xl lg:max-w-screen-xl xl:max-w-[50%]">Max-Width</div>
+        <div class="h-0 sm:h-px md:h-1/2 lg:h-max xl:h-[32rem]">Height</div>
+        <div class="min-h-0 sm:min-h-full md:min-h-min lg:min-h-max xl:min-h-[50%]">Min-Height</div>
+        <div class="max-h-0 sm:max-h-2 md:max-h-full lg:max-h-screen xl:max-h-[32rem]">Max-Height</div>
+        <div class=""></div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Typography</h1>
-          <div class="font-sans sm:font-serif md:font-mono lg:font-['Open_Sans']">Font Family</div>
-          <div class="text-xs sm:text-base md:text-2xl lg:text-[14px]">Font Size</div>
-          <div class="antialiased sm:subpixel-antialiased">Font Smoothing</div>
-          <div class="italic sm:not-italic">Font Style</div>
-          <div class="font-thin sm:font-extralight md:font-light lg:font-normal xl:font-medium dark:font-semibold sm:dark:font-bold md:dark:font-extrabold lg:dark:font-black xl:dark:font-[1100]">Font Weight</div>
-          <div class="ordinal slashed-zero tabular-nums sm:normal-nums md:lining-nums lg:oldstyle-nums xl:proportional-nums 2xl:tabular-nums">Font Variant Numeric</div>
-          <div class="tracking-tighter sm:tracking-tight md:tracking-normal lg:tracking-wide xl:tracking-wider 2xl:tracking-widest dark:tracking-[.25em] sm:dark:-tracking-wide md:dark:-tracking-normal lg:dark:tracking-[-.25em]">Letter Spacing</div>
-          <div class="leading-3 sm:leading-none md:leading-tight lg:leading-snug xl:leading-normal 2xl:leading-relaxed dark:leading-loose sm:dark:leading-[3rem]">Line Height</div>
-          <div class="list-none sm:list-disc md:list-decimal lg:list-[upper-roman]">List Style Type</div>
-          <div class="list-inside sm:list-outside">List Style Position</div>
-          <div class="text-left sm:text-center md:text-right lg:text-justify">Text Alignment</div>
-          <div class="text-inherit sm:text-current md:text-transparent lg:text-black xl:text-white 2xl:text-slate-200 dark:text-[#50d71e] sm:dark:text-[color:var(--yolo)] first:text-black/50 last:text-[#F005] even:text-[#F0F5F6B8] odd:text-[rgba(100,10,140,.5)]">Text Color</div>
-          <div class="underline sm:overline md:line-through lg:no-underline">Text Decoration</div>
-          <div class="decoration-inherit sm:decoration-current md:decoration-transparent lg:text-black xl:decoration-white 2xl:decoration-slate-200 dark:decoration-[#50d71e] sm:dark:decoration-[color:var(--yolo)] first:decoration-black/50 last:decoration-[#F005] even:decoration-[#F0F5F6B8] odd:decoration-[rgba(100,10,140,.5)]">Text Decoration Color</div>
-          <div class="decoration-solid sm:decoration-double md:decoration-dotted lg:decoration-dashed xl:decoration-wavy">Text Decoration Style</div>
-          <div class="decoration-auto sm:decoration-from-font md:decoration-0 lg:decoration-8 xl:decoration-[3px] 2xl:decoration-[length:var(--yolo)]">Text Decoration Thickness</div>
-          <div class="underline-offset-auto sm:underline-offset-0 md:underline-offset-8 underline-offset-[3px]">Text Underline Offset</div>
-          <div class="uppercase sm:lowercase md:capitalize lg:normal-case">Text Transform</div>
-          <div class="truncate sm:text-ellipsis md:text-clip">Text Overflow</div>
-          <div class="indent-0 sm:indent-3 md:indent-[50%] lg:-indent-3 xl:indent-[-10px]">Text Indent</div>
-          <div class="align-baseline sm:align-top md:align-middle lg:align-bottom xl:align-text-top dark:align-text-bottom sm:dark:align-sub md:dark:align-super">Vertical Alignment</div>
-          <div class="whitespace-normal sm:whitespace-nowrap md:whitespace-pre lg:whitespace-pre-line xl:whitespace-pre-wrap">Whitespace</div>
-          <div class="break-normal sm:break-words md:break-all">Word Break</div>
-          <div class="content-none after:content-['_↗'] before:content-[attr(before)] sm:before:content-['Hello_World'] md:before:content-['Hello\_World'] lg:before:content-[url('/icons/link.svg')]">Content</div>
-        </section>`,
+      <section>
+        <h1>Typography</h1>
+        <div class="font-sans sm:font-serif md:font-mono lg:font-['Open_Sans']">Font Family</div>
+        <div class="text-xs sm:text-base md:text-2xl lg:text-[14px]">Font Size</div>
+        <div class="antialiased sm:subpixel-antialiased">Font Smoothing</div>
+        <div class="italic sm:not-italic">Font Style</div>
+        <div class="font-thin sm:font-extralight md:font-light lg:font-normal xl:font-medium dark:font-semibold sm:dark:font-bold md:dark:font-extrabold lg:dark:font-black xl:dark:font-[1100]">Font Weight</div>
+        <div class="ordinal slashed-zero tabular-nums sm:normal-nums md:lining-nums lg:oldstyle-nums xl:proportional-nums 2xl:tabular-nums">Font Variant Numeric</div>
+        <div class="tracking-tighter sm:tracking-tight md:tracking-normal lg:tracking-wide xl:tracking-wider 2xl:tracking-widest dark:tracking-[.25em] sm:dark:-tracking-wide md:dark:-tracking-normal lg:dark:tracking-[-.25em]">Letter Spacing</div>
+        <div class="leading-3 sm:leading-none md:leading-tight lg:leading-snug xl:leading-normal 2xl:leading-relaxed dark:leading-loose sm:dark:leading-[3rem]">Line Height</div>
+        <div class="list-none sm:list-disc md:list-decimal lg:list-[upper-roman]">List Style Type</div>
+        <div class="list-inside sm:list-outside">List Style Position</div>
+        <div class="text-left sm:text-center md:text-right lg:text-justify">Text Alignment</div>
+        <div class="text-inherit sm:text-current md:text-transparent lg:text-black xl:text-white 2xl:text-slate-200 dark:text-[#50d71e] sm:dark:text-[color:var(--yolo)] first:text-black/50 last:text-[#F005] even:text-[#F0F5F6B8] odd:text-[rgba(100,10,140,.5)]">Text Color</div>
+        <div class="underline sm:overline md:line-through lg:no-underline">Text Decoration</div>
+        <div class="decoration-inherit sm:decoration-current md:decoration-transparent lg:text-black xl:decoration-white 2xl:decoration-slate-200 dark:decoration-[#50d71e] sm:dark:decoration-[color:var(--yolo)] first:decoration-black/50 last:decoration-[#F005] even:decoration-[#F0F5F6B8] odd:decoration-[rgba(100,10,140,.5)]">Text Decoration Color</div>
+        <div class="decoration-solid sm:decoration-double md:decoration-dotted lg:decoration-dashed xl:decoration-wavy">Text Decoration Style</div>
+        <div class="decoration-auto sm:decoration-from-font md:decoration-0 lg:decoration-8 xl:decoration-[3px] 2xl:decoration-[length:var(--yolo)]">Text Decoration Thickness</div>
+        <div class="underline-offset-auto sm:underline-offset-0 md:underline-offset-8 underline-offset-[3px]">Text Underline Offset</div>
+        <div class="uppercase sm:lowercase md:capitalize lg:normal-case">Text Transform</div>
+        <div class="truncate sm:text-ellipsis md:text-clip">Text Overflow</div>
+        <div class="indent-0 sm:indent-3 md:indent-[50%] lg:-indent-3 xl:indent-[-10px]">Text Indent</div>
+        <div class="align-baseline sm:align-top md:align-middle lg:align-bottom xl:align-text-top dark:align-text-bottom sm:dark:align-sub md:dark:align-super">Vertical Alignment</div>
+        <div class="whitespace-normal sm:whitespace-nowrap md:whitespace-pre lg:whitespace-pre-line xl:whitespace-pre-wrap">Whitespace</div>
+        <div class="break-normal sm:break-words md:break-all">Word Break</div>
+        <div class="content-none after:content-['_↗'] before:content-[attr(before)] sm:before:content-['Hello_World'] md:before:content-['Hello\_World'] lg:before:content-[url('/icons/link.svg')]">Content</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Backgrounds</h1>
-          <div class="bg-fixed sm:bg-local md:bg-scroll">Background Attachment</div>
-          <div class="bg-clip-border sm:bg-clip-padding md:bg-clip-content lg:bg-clip-text">Background Clip</div>
-          <div class="bg-inherit sm:bg-current md:bg-black lg:bg-lime-900 xl:bg-[#50d71e] 2xl:bg-[color:var(--some)]">Background Color</div>
-          <div class="bg-origin-border sm:bg-origin-padding md:bg-origin-content">Background Origin</div>
-          <div class="bg-bottom sm:bg-center md:bg-left lg:bg-left-bottom xl:bg-left-top 2xl:bg-right dark:bg-right-bottom sm:dark:bg-right-top md:dark:bg-top lg:dark:bg-[center_top_1rem]">Background Position</div>
-          <div class="bg-repeat sm:bg-no-repeat md:bg-repeat-x lg:bg-repeat-y xl:bg-repeat-round 2xl:bg-repeat-space">Background Repeat</div>
-          <div class="bg-auto sm:bg-cover md:bg-contain lg:bg-[length:200px_100px]">Background Size</div>
-          <div class="bg-none sm:bg-gradient-to-tr md:bg-[url('/img/hero-pattern.svg')]">Background Image</div>
-          <div class="from-inherit sm:from-current md:from-transparent lg:from-black xl:from-[#243c5a] 2xl:from-[#243c5a/50] first:from-black/50 last:from-[#F005] even:from-[#F0F5F6B8] odd:from-[rgba(100,10,140,.5)]">Gradient Color Stops</div>
-        </section>`,
+      <section>
+        <h1>Backgrounds</h1>
+        <div class="bg-fixed sm:bg-local md:bg-scroll">Background Attachment</div>
+        <div class="bg-clip-border sm:bg-clip-padding md:bg-clip-content lg:bg-clip-text">Background Clip</div>
+        <div class="bg-inherit sm:bg-current md:bg-black lg:bg-lime-900 xl:bg-[#50d71e] 2xl:bg-[color:var(--some)]">Background Color</div>
+        <div class="bg-origin-border sm:bg-origin-padding md:bg-origin-content">Background Origin</div>
+        <div class="bg-bottom sm:bg-center md:bg-left lg:bg-left-bottom xl:bg-left-top 2xl:bg-right dark:bg-right-bottom sm:dark:bg-right-top md:dark:bg-top lg:dark:bg-[center_top_1rem]">Background Position</div>
+        <div class="bg-repeat sm:bg-no-repeat md:bg-repeat-x lg:bg-repeat-y xl:bg-repeat-round 2xl:bg-repeat-space">Background Repeat</div>
+        <div class="bg-auto sm:bg-cover md:bg-contain lg:bg-[length:200px_100px]">Background Size</div>
+        <div class="bg-none sm:bg-gradient-to-tr md:bg-[url('/img/hero-pattern.svg')]">Background Image</div>
+        <div class="from-inherit sm:from-current md:from-transparent lg:from-black xl:from-[#243c5a] 2xl:from-[#243c5a/50] first:from-black/50 last:from-[#F005] even:from-[#F0F5F6B8] odd:from-[rgba(100,10,140,.5)]">Gradient Color Stops</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Borders</h1>
-          <div class="rounded-none sm:rounded-xl md:rounded-t-md lg:rounded-br-3xl xl:rounded-[12px]">Border Radius</div>
-          <div class="border sm:border-0 md:border-x-2 lg:border-y-8 xl:border-r 2xl:border-t-[3px]">Border Width</div>
-          <div class="border-transparent sm:border-rose-500 md:border-t-indigo-500/75 lg:border-x-indigo-500 xl:border-[#243c5a] first:border-black/50 last:border-[#F005] even:border-[#F0F5F6B8] odd:border-[rgba(100,10,140,.5)]">Border Color</div>
-          <div class="border-solid sm:border-dashed md:border-dotted lg:border-double xl:border-hidden 2xl:border-none">Border Style</div>
-          <div class="divide-y-4 sm:divide-x-8 md:divide-y lg:divide-y-reverse xl:divide-x-reverse 2xl:divide-x-[3px]">Divide Width</div>
-          <div class="divide-gray-400/25 sm:divide-amber-400 md:divide-[#243c5a] first:divide-black/50 last:divide-[#F005] even:divide-[#F0F5F6B8] odd:divide-[rgba(100,10,140,.5)]">Divide Color</div>
-          <div class="divide-solid sm:divide-dashed md:divide-dotted lg:divide-double xl:divide-none">Divide Style</div>
-          <div class="outline-0 sm:outline-4 md:outline-[5px]">Outline Width</div>
-          <div class="outline-inherit sm:outline-current md:outline-black lg:outline-lime-900 xl:outline-[#50d71e] 2xl:outline-[color:var(--some)] first:outline-black/50 last:outline-[#F005] even:outline-[#F0F5F6B8] odd:outline-[rgba(100,10,140,.5)]">Outline Color</div>
-          <div class="outline-none sm:outline md:outline-dashed lg:outline-dotted xl:outline-double 2xl:outline-hidden">Outline Style</div>
-          <div class="outline-offset-4 sm:outline-offset-[3px]">Outline Offset</div>
-          <div class="ring-0 sm:ring-4 md:ring-inset lg:ring-[10px]">Ring Width</div>
-          <div class="ring-inherit sm:ring-current md:ring-black lg:ring-lime-900 xl:ring-[#50d71e] 2xl:ring-[color:var(--some)] first:ring-black/50 last:ring-[#F005] even:ring-[#F0F5F6B8] odd:ring-[rgba(100,10,140,.5)]">Ring Color</div>
-          <div class="ring-offset-4 sm:ring-offset-[3px]">Ring Offset Width</div>
-          <div class="ring-offset-inherit sm:ring-offset-current md:ring-offset-black lg:ring-offset-lime-900 xl:ring-offset-[#50d71e] 2xl:ring-offset-[color:var(--some)] first:ring-offset-black/50 last:ring-offset-[#F005] even:ring-offset-[#F0F5F6B8] odd:ring-offset-[rgba(100,10,140,.5)]">Ring Offset Color</div>
-        </section>`,
+      <section>
+        <h1>Borders</h1>
+        <div class="rounded-none sm:rounded-xl md:rounded-t-md lg:rounded-br-3xl xl:rounded-[12px]">Border Radius</div>
+        <div class="border sm:border-0 md:border-x-2 lg:border-y-8 xl:border-r 2xl:border-t-[3px]">Border Width</div>
+        <div class="border-transparent sm:border-rose-500 md:border-t-indigo-500/75 lg:border-x-indigo-500 xl:border-[#243c5a] first:border-black/50 last:border-[#F005] even:border-[#F0F5F6B8] odd:border-[rgba(100,10,140,.5)]">Border Color</div>
+        <div class="border-solid sm:border-dashed md:border-dotted lg:border-double xl:border-hidden 2xl:border-none">Border Style</div>
+        <div class="divide-y-4 sm:divide-x-8 md:divide-y lg:divide-y-reverse xl:divide-x-reverse 2xl:divide-x-[3px]">Divide Width</div>
+        <div class="divide-gray-400/25 sm:divide-amber-400 md:divide-[#243c5a] first:divide-black/50 last:divide-[#F005] even:divide-[#F0F5F6B8] odd:divide-[rgba(100,10,140,.5)]">Divide Color</div>
+        <div class="divide-solid sm:divide-dashed md:divide-dotted lg:divide-double xl:divide-none">Divide Style</div>
+        <div class="outline-0 sm:outline-4 md:outline-[5px]">Outline Width</div>
+        <div class="outline-inherit sm:outline-current md:outline-black lg:outline-lime-900 xl:outline-[#50d71e] 2xl:outline-[color:var(--some)] first:outline-black/50 last:outline-[#F005] even:outline-[#F0F5F6B8] odd:outline-[rgba(100,10,140,.5)]">Outline Color</div>
+        <div class="outline-none sm:outline md:outline-dashed lg:outline-dotted xl:outline-double 2xl:outline-hidden">Outline Style</div>
+        <div class="outline-offset-4 sm:outline-offset-[3px]">Outline Offset</div>
+        <div class="ring-0 sm:ring-4 md:ring-inset lg:ring-[10px]">Ring Width</div>
+        <div class="ring-inherit sm:ring-current md:ring-black lg:ring-lime-900 xl:ring-[#50d71e] 2xl:ring-[color:var(--some)] first:ring-black/50 last:ring-[#F005] even:ring-[#F0F5F6B8] odd:ring-[rgba(100,10,140,.5)]">Ring Color</div>
+        <div class="ring-offset-4 sm:ring-offset-[3px]">Ring Offset Width</div>
+        <div class="ring-offset-inherit sm:ring-offset-current md:ring-offset-black lg:ring-offset-lime-900 xl:ring-offset-[#50d71e] 2xl:ring-offset-[color:var(--some)] first:ring-offset-black/50 last:ring-offset-[#F005] even:ring-offset-[#F0F5F6B8] odd:ring-offset-[rgba(100,10,140,.5)]">Ring Offset Color</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Effects</h1>
-          <div class="shadow sm:shadow-lg md:shadow-inner lg:shadow-none xl:shadow-[0_35px_60px_-15px_rgba(0,0,0,0.3)]">Box Shadow</div>
-          <div class="shadow-inherit sm:shadow-current md:shadow-black lg:shadow-lime-900 xl:shadow-[#50d71e] 2xl:shadow-[color:var(--some)] first:shadow-black/50 last:shadow-[#F005] even:shadow-[#F0F5F6B8] odd:shadow-[rgba(100,10,140,.5)]">Box Shadow Color</div>
-          <div class="opacity-0 sm:opacity-50 md:opacity-[.67]">Opacity</div>
-          <div class="mix-blend-normal sm:mix-blend-multiply md:mix-blend-screen lg:mix-blend-overlay xl:mix-blend-darken 2xl:mix-blend-lighten dark:mix-blend-color-dodge sm:dark:mix-blend-color-burn md:dark:mix-blend-hard-light lg:dark:mix-blend-soft-light xl:dark:mix-blend-difference 2xl:dark:mix-blend-exclusion hover:mix-blend-hue first:mix-blend-saturation last:mix-blend-color focus:mix-blend-luminosity">Mix Blend Mode</div>
-          <div class="bg-blend-normal sm:bg-blend-multiply md:bg-blend-screen lg:bg-blend-overlay xl:bg-blend-darken 2xl:bg-blend-lighten dark:bg-blend-color-dodge focus:bg-blend-color-burn link:bg-blend-hard-light visited:bg-blend-soft-light hover:bg-blend-difference active:bg-blend-exclusion first:bg-blend-hue last:bg-blend-saturation odd:bg-blend-color even:bg-blend-luminosity">Background Blend Mode</div>
-        </section>`,
+      <section>
+        <h1>Effects</h1>
+        <div class="shadow sm:shadow-lg md:shadow-inner lg:shadow-none xl:shadow-[0_35px_60px_-15px_rgba(0,0,0,0.3)]">Box Shadow</div>
+        <div class="shadow-inherit sm:shadow-current md:shadow-black lg:shadow-lime-900 xl:shadow-[#50d71e] 2xl:shadow-[color:var(--some)] first:shadow-black/50 last:shadow-[#F005] even:shadow-[#F0F5F6B8] odd:shadow-[rgba(100,10,140,.5)]">Box Shadow Color</div>
+        <div class="opacity-0 sm:opacity-50 md:opacity-[.67]">Opacity</div>
+        <div class="mix-blend-normal sm:mix-blend-multiply md:mix-blend-screen lg:mix-blend-overlay xl:mix-blend-darken 2xl:mix-blend-lighten dark:mix-blend-color-dodge sm:dark:mix-blend-color-burn md:dark:mix-blend-hard-light lg:dark:mix-blend-soft-light xl:dark:mix-blend-difference 2xl:dark:mix-blend-exclusion hover:mix-blend-hue first:mix-blend-saturation last:mix-blend-color focus:mix-blend-luminosity">Mix Blend Mode</div>
+        <div class="bg-blend-normal sm:bg-blend-multiply md:bg-blend-screen lg:bg-blend-overlay xl:bg-blend-darken 2xl:bg-blend-lighten dark:bg-blend-color-dodge focus:bg-blend-color-burn link:bg-blend-hard-light visited:bg-blend-soft-light hover:bg-blend-difference active:bg-blend-exclusion first:bg-blend-hue last:bg-blend-saturation odd:bg-blend-color even:bg-blend-luminosity">Background Blend Mode</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Filters</h1>
-          <div class="blur-none sm:blur md:blur-lg lg:blur-[2px]">Blur</div>
-          <div class="brightness-0 sm:brightness-100 md:brightness-[1.75]">Brightness</div>
-          <div class="contrast-0 sm:contrast-100 md:contrast-[.75]">Contrast</div>
-          <div class="drop-shadow sm:drop-shadow-none md:drop-shadow-xl lg:drop-shadow-[0_35px_35px_rgba(0,0,0,0.25)]">Drop Shadow</div>
-          <div class="grayscale sm:grayscale-0 md:grayscale-[50%]">Grayscale</div>
-          <div class="hue-rotate-0 sm:hue-rotate-90 md:-hue-rotate-15 lg:hue-rotate-[270deg] xl:hue-rotate-[-7deg] 2xl:hue-rotate-[var(--yolo)]">Hue Rotate</div>
-          <div class="invert sm:invert-0 md:invert-[.25]">Invert</div>
-          <div class="saturate-0 sm:saturate-150 md:saturate-[.25]">Saturate</div>
-          <div class="sepia-0 sm:sepia md:sepia-[.25]">Sepia</div>
-          <div class="backdrop-blur sm:backdrop-blur-lg md:backdrop-blur-[2px]">Backdrop Blur</div>
-          <div class="backdrop-brightness-50 sm:backdrop-brightness-200 md:backdrop-brightness-[1.75]">Backdrop Brightness</div>
-          <div class="backdrop-contrast-100 sm:backdrop-contrast-0 md:backdrop-contrast-[.25]">Backdrop Contrast</div>
-          <div class="backdrop-grayscale-0 sm:backdrop-grayscale md:backdrop-grayscale-[.5]">Backdrop Grayscale</div>
-          <div class="-backdrop-hue-rotate-15 sm:backdrop-hue-rotate-15 md:backdrop-hue-rotate-[15deg]">Backdrop Hue Rotate</div>
-          <div class="backdrop-invert-0 sm:backdrop-invert md:backdrop-invert-[.25]">Backdrop Invert</div>
-          <div class="backdrop-opacity-50 sm:backdrop-opacity-25 md:backdrop-opacity-[.15]">Backdrop Opacity</div>
-          <div class="backdrop-saturate-150 sm:backdrop-saturate-50 md:backdrop-saturate-[.25]">Backdrop Saturate</div>
-          <div class="backdrop-sepia sm:backdrop-sepia-0 md:backdrop-sepia-[.25]">Backdrop Sepia</div>
-        </section>`,
+      <section>
+        <h1>Filters</h1>
+        <div class="blur-none sm:blur md:blur-lg lg:blur-[2px]">Blur</div>
+        <div class="brightness-0 sm:brightness-100 md:brightness-[1.75]">Brightness</div>
+        <div class="contrast-0 sm:contrast-100 md:contrast-[.75]">Contrast</div>
+        <div class="drop-shadow sm:drop-shadow-none md:drop-shadow-xl lg:drop-shadow-[0_35px_35px_rgba(0,0,0,0.25)]">Drop Shadow</div>
+        <div class="grayscale sm:grayscale-0 md:grayscale-[50%]">Grayscale</div>
+        <div class="hue-rotate-0 sm:hue-rotate-90 md:-hue-rotate-15 lg:hue-rotate-[270deg] xl:hue-rotate-[-7deg] 2xl:hue-rotate-[var(--yolo)]">Hue Rotate</div>
+        <div class="invert sm:invert-0 md:invert-[.25]">Invert</div>
+        <div class="saturate-0 sm:saturate-150 md:saturate-[.25]">Saturate</div>
+        <div class="sepia-0 sm:sepia md:sepia-[.25]">Sepia</div>
+        <div class="backdrop-blur sm:backdrop-blur-lg md:backdrop-blur-[2px]">Backdrop Blur</div>
+        <div class="backdrop-brightness-50 sm:backdrop-brightness-200 md:backdrop-brightness-[1.75]">Backdrop Brightness</div>
+        <div class="backdrop-contrast-100 sm:backdrop-contrast-0 md:backdrop-contrast-[.25]">Backdrop Contrast</div>
+        <div class="backdrop-grayscale-0 sm:backdrop-grayscale md:backdrop-grayscale-[.5]">Backdrop Grayscale</div>
+        <div class="-backdrop-hue-rotate-15 sm:backdrop-hue-rotate-15 md:backdrop-hue-rotate-[15deg]">Backdrop Hue Rotate</div>
+        <div class="backdrop-invert-0 sm:backdrop-invert md:backdrop-invert-[.25]">Backdrop Invert</div>
+        <div class="backdrop-opacity-50 sm:backdrop-opacity-25 md:backdrop-opacity-[.15]">Backdrop Opacity</div>
+        <div class="backdrop-saturate-150 sm:backdrop-saturate-50 md:backdrop-saturate-[.25]">Backdrop Saturate</div>
+        <div class="backdrop-sepia sm:backdrop-sepia-0 md:backdrop-sepia-[.25]">Backdrop Sepia</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Tables</h1>
-          <div class="border-collapse md:border-separate">Border Collapse</div>
-          <div class="table-auto sm:table-fixed">Table Layout</div>
-        </section>`,
+      <section>
+        <h1>Tables</h1>
+        <div class="border-collapse md:border-separate">Border Collapse</div>
+        <div class="table-auto sm:table-fixed">Table Layout</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Transitions & Animation</h1>
-          <div class="transition-none sm:transition-all md:transition lg:transition-colors xl:transition-opacity 2xl:transition-shadow dark:transition-transform first:transition-[height]">Transition Property</div>
-          <div class="duration-100 sm:duration-200 md:duration-[2000ms]">Transition Duration</div>
-          <div class="ease-linear sm:ease-in md:ease-out lg:ease-in-out xl:ease-[cubic-bezier(0.95,0.05,0.795,0.035)]">Transition Timing Function</div>
-          <div class="delay-75 sm:delay-500 md:delay-[2000ms]">Transition Delay</div>
-          <div class="animate-none sm:animate-spin md:animate-ping lg:animate-pulse xl:animate-bounce 2xl:animate-[wiggle_1s_ease-in-out_infinite]">Animation</div>
-        </section>`,
+      <section>
+        <h1>Transitions & Animation</h1>
+        <div class="transition-none sm:transition-all md:transition lg:transition-colors xl:transition-opacity 2xl:transition-shadow dark:transition-transform first:transition-[height]">Transition Property</div>
+        <div class="duration-100 sm:duration-200 md:duration-[2000ms]">Transition Duration</div>
+        <div class="ease-linear sm:ease-in md:ease-out lg:ease-in-out xl:ease-[cubic-bezier(0.95,0.05,0.795,0.035)]">Transition Timing Function</div>
+        <div class="delay-75 sm:delay-500 md:delay-[2000ms]">Transition Delay</div>
+        <div class="animate-none sm:animate-spin md:animate-ping lg:animate-pulse xl:animate-bounce 2xl:animate-[wiggle_1s_ease-in-out_infinite]">Animation</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Transforms</h1>
-          <div class="scale-x-50 sm:scale-y-75 md:scale-0 lg:scale-[1.7] transform-gpu">Scale</div>
-          <div class="rotate-45 sm:-rotate-90 md:rotate-[17deg]">Rotate</div>
-          <div class="translate-x-2.5 sm:translate-y-3 md:-translate-y-10 lg:translate-y-[17rem]">Translate</div>
-          <div class="skew-y-3 skew-x-6 sm:-skew-y-6 md:skew-y-[17deg] lg:skew-y-[-45deg]">Skew</div>
-          <div class="origin-center sm:origin-top md:origin-top-right lg:origin-right xl:origin-bottom-right dark:origin-bottom first:origin-bottom-left last:origin-left odd:origin-top-left even:origin-[33%_75%]">Transform Origin</div>
-        </section>`,
+      <section>
+        <h1>Transforms</h1>
+        <div class="scale-x-50 sm:scale-y-75 md:scale-0 lg:scale-[1.7] transform-gpu">Scale</div>
+        <div class="rotate-45 sm:-rotate-90 md:rotate-[17deg]">Rotate</div>
+        <div class="translate-x-2.5 sm:translate-y-3 md:-translate-y-10 lg:translate-y-[17rem]">Translate</div>
+        <div class="skew-y-3 skew-x-6 sm:-skew-y-6 md:skew-y-[17deg] lg:skew-y-[-45deg]">Skew</div>
+        <div class="origin-center sm:origin-top md:origin-top-right lg:origin-right xl:origin-bottom-right dark:origin-bottom first:origin-bottom-left last:origin-left odd:origin-top-left even:origin-[33%_75%]">Transform Origin</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Interactivity</h1>
-          <div class="accent-emerald-500/25 sm:accent-violet-300 2xl:accent-[#50d71e] first:accent-black/50 last:accent-[#F005] even:accent-[#F0F5F6B8] odd:accent-[rgba(100,10,140,.5)]">Accent Color</div>
-          <div class="appearance-none">Appearance</div>
-          <div class="cursor-auto sm:cursor-default md:cursor-pointer lg:cursor-wait xl:cursor-text 2xl:cursor-move dark:cursor-help sm:dark:cursor-not-allowed md:dark:cursor-none lg:dark:cursor-context-menu xl:dark:cursor-progress 2xl:dark:cursor-cell dark:focus:cursor-crosshair dark:active:cursor-vertical-text dark:valid:cursor-alias first:cursor-copy last:cursor-no-drop even:cursor-grab odd:cursor-grabbing empty:cursor-all-scroll disabled:cursor-col-resize active:cursor-row-resize visited:cursor-n-resize hover:cursor-e-resize focus:cursor-s-resize link:cursor-w-resize only:cursor-ne-resize focus-visible:cursor-nw-resize disabled:cursor-se-resize checked:cursor-sw-resize required:cursor-ew-resize invalid:cursor-ns-resize valid:cursor-nesw-resize in-range:cursor-nwse-resize out-of-range:cursor-zoom-in open:cursor-zoom-out open:first:cursor-[url(hand.cur),_pointer]">Cursor</div>
-          <div class="caret-emerald-500/25 sm:caret-violet-300 2xl:caret-[#50d71e] first:caret-black/50 last:caret-[#F005] even:caret-[#F0F5F6B8] odd:caret-[rgba(100,10,140,.5)]">Caret Color</div>
-          <div class="pointer-events-none sm:pointer-events-auto">Pointer Events</div>
-          <div class="resize-none sm:resize-y md:resize-x lg:resize">Resize</div>
-          <div class="scroll-auto sm:scroll-smooth">Scroll Behavior</div>
-          <div class="scroll-m-0 sm:scroll-mx-px md:scroll-my-0.5 lg:scroll-mb-1 xl:-scroll-mr-1 2xl:scroll-m-[24rem]">Scroll Margin</div>
-          <div class="scroll-p-0 sm:scroll-px-px md:scroll-py-0.5 lg:scroll-pb-1 xl:scroll-pr-1 2xl:scroll-p-[24rem]">Scroll Padding</div>
-          <div class="snap-start sm:snap-end md:snap-center lg:snap-align-none">Scroll Snap Align</div>
-          <div class="snap-normal sm:snap-always">Scroll Snap Stop</div>
-          <div class="snap-none sm:snap-x md:snap-y lg:snap-both xl:snap-mandatory 2xl:snap-proximity">Scroll Snap Type</div>
-          <div class="touch-auto sm:touch-none md:touch-pan-x lg:touch-pan-left xl:touch-pan-right 2xl:touch-pan-y dark::touch-pan-up first:touch-pan-down last:touch-pinch-zoom focus:touch-manipulation">Touch Action</div>
-          <div class="select-none sm:select-text md:select-all lg:select-auto">User Select</div>
-          <div class="will-change-auto sm:will-change-scroll md:will-change-contents lg:will-change-transform">Will Change</div>
-        </section>`,
+      <section>
+        <h1>Interactivity</h1>
+        <div class="accent-emerald-500/25 sm:accent-violet-300 2xl:accent-[#50d71e] first:accent-black/50 last:accent-[#F005] even:accent-[#F0F5F6B8] odd:accent-[rgba(100,10,140,.5)]">Accent Color</div>
+        <div class="appearance-none">Appearance</div>
+        <div class="cursor-auto sm:cursor-default md:cursor-pointer lg:cursor-wait xl:cursor-text 2xl:cursor-move dark:cursor-help sm:dark:cursor-not-allowed md:dark:cursor-none lg:dark:cursor-context-menu xl:dark:cursor-progress 2xl:dark:cursor-cell dark:focus:cursor-crosshair dark:active:cursor-vertical-text dark:valid:cursor-alias first:cursor-copy last:cursor-no-drop even:cursor-grab odd:cursor-grabbing empty:cursor-all-scroll disabled:cursor-col-resize active:cursor-row-resize visited:cursor-n-resize hover:cursor-e-resize focus:cursor-s-resize link:cursor-w-resize only:cursor-ne-resize focus-visible:cursor-nw-resize disabled:cursor-se-resize checked:cursor-sw-resize required:cursor-ew-resize invalid:cursor-ns-resize valid:cursor-nesw-resize in-range:cursor-nwse-resize out-of-range:cursor-zoom-in open:cursor-zoom-out open:first:cursor-[url(hand.cur),_pointer]">Cursor</div>
+        <div class="caret-emerald-500/25 sm:caret-violet-300 2xl:caret-[#50d71e] first:caret-black/50 last:caret-[#F005] even:caret-[#F0F5F6B8] odd:caret-[rgba(100,10,140,.5)]">Caret Color</div>
+        <div class="pointer-events-none sm:pointer-events-auto">Pointer Events</div>
+        <div class="resize-none sm:resize-y md:resize-x lg:resize">Resize</div>
+        <div class="scroll-auto sm:scroll-smooth">Scroll Behavior</div>
+        <div class="scroll-m-0 sm:scroll-mx-px md:scroll-my-0.5 lg:scroll-mb-1 xl:-scroll-mr-1 2xl:scroll-m-[24rem]">Scroll Margin</div>
+        <div class="scroll-p-0 sm:scroll-px-px md:scroll-py-0.5 lg:scroll-pb-1 xl:scroll-pr-1 2xl:scroll-p-[24rem]">Scroll Padding</div>
+        <div class="snap-start sm:snap-end md:snap-center lg:snap-align-none">Scroll Snap Align</div>
+        <div class="snap-normal sm:snap-always">Scroll Snap Stop</div>
+        <div class="snap-none sm:snap-x md:snap-y lg:snap-both xl:snap-mandatory 2xl:snap-proximity">Scroll Snap Type</div>
+        <div class="touch-auto sm:touch-none md:touch-pan-x lg:touch-pan-left xl:touch-pan-right 2xl:touch-pan-y dark::touch-pan-up first:touch-pan-down last:touch-pinch-zoom focus:touch-manipulation">Touch Action</div>
+        <div class="select-none sm:select-text md:select-all lg:select-auto">User Select</div>
+        <div class="will-change-auto sm:will-change-scroll md:will-change-contents lg:will-change-transform">Will Change</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>SVG</h1>
-          <div class="fill-emerald-500 sm:fill-violet-300 2xl:fill-[#50d71e] first:fill-black/50 last:fill-[#F005] even:fill-[#F0F5F6B8] odd:fill-[rgba(100,10,140,.5)]">Fill</div>
-          <div class="stroke-emerald-500 sm:stroke-violet-300 2xl:stroke-[#50d71e] first:stroke-black/50 last:stroke-[#F005] even:stroke-[#F0F5F6B8] odd:stroke-[rgba(100,10,140,.5)]">Stroke</div>
-          <div class="stroke-0 sm:stroke-1 md:stroke-2 lg:stroke-[2px]">Stroke Width</div>
-        </section>`,
+      <section>
+        <h1>SVG</h1>
+        <div class="fill-emerald-500 sm:fill-violet-300 2xl:fill-[#50d71e] first:fill-black/50 last:fill-[#F005] even:fill-[#F0F5F6B8] odd:fill-[rgba(100,10,140,.5)]">Fill</div>
+        <div class="stroke-emerald-500 sm:stroke-violet-300 2xl:stroke-[#50d71e] first:stroke-black/50 last:stroke-[#F005] even:stroke-[#F0F5F6B8] odd:stroke-[rgba(100,10,140,.5)]">Stroke</div>
+        <div class="stroke-0 sm:stroke-1 md:stroke-2 lg:stroke-[2px]">Stroke Width</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Accessibility</h1>
-          <div class="sr-only sm:not-sr-only">Screen Readers</div>
-        </section>`,
+      <section>
+        <h1>Accessibility</h1>
+        <div class="sr-only sm:not-sr-only">Screen Readers</div>
+      </section>`,
     },
     {
       code: `
-        <section>
-          <h1>Official Plugins</h1>
-          <div class=""></div>
-        </section>`,
+      <section>
+        <h1>Official Plugins</h1>
+        <div class=""></div>
+      </section>`,
     },
     {
       code: `<template><div class="container box-content lg:box-border max-h-24 self-end">Only Tailwind CSS classnames</div></template>`,
@@ -349,14 +349,14 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        ctl(\`
-          sm:w-6
-          w-8
-          container
-          w-12
-          flex
-          lg:w-4
-        \`);`,
+      ctl(\`
+        sm:w-6
+        w-8
+        container
+        w-12
+        flex
+        lg:w-4
+      \`);`,
     },
     {
       code: `<div class="tw-container tw-box-content lg_tw-box-border">Only Tailwind CSS classnames</div>`,
@@ -419,16 +419,16 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <div class="group border-indigo-500 hover:bg-white hover:shadow-lg hover:border-transparent">
-        <p class="text-indigo-600 group-hover:text-gray-900">New Project</p>
-        <p class="text-indigo-500 group-hover:text-gray-500">Create a new project from a variety of starting templates.</p>
-        </div>`,
+      <div class="group border-indigo-500 hover:bg-white hover:shadow-lg hover:border-transparent">
+      <p class="text-indigo-600 group-hover:text-gray-900">New Project</p>
+      <p class="text-indigo-500 group-hover:text-gray-500">Create a new project from a variety of starting templates.</p>
+      </div>`,
     },
     {
       code: `
-        <div class="some base white-listed classnames">
-          from css file
-        </div>`,
+      <div class="some base white-listed classnames">
+        from css file
+      </div>`,
       options: [
         {
           cssFiles: ["./tests/**/*.css"],
@@ -437,96 +437,96 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        myTag\`
-          sm:w-6
-          w-8
-          container
-          w-12
-          flex
-          lg:w-4
-        \`;`,
+      myTag\`
+        sm:w-6
+        w-8
+        container
+        w-12
+        flex
+        lg:w-4
+      \`;`,
       options: [{ tags: ["myTag"] }],
     },
     {
       code: `
-        <div class="flex flex-row-reverse space-x-4 space-x-reverse">
-          <div>1</div>
-          <div>2</div>
-          <div>3</div>
-        </div>`,
+      <div class="flex flex-row-reverse space-x-4 space-x-reverse">
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+      </div>`,
     },
     {
       code: `
-        <div class="text-red-700 border-2 border-current bg-current p-10">
-          <input class="bg-gray-500 text-white placeholder:text-black" placeholder="placeholder color" />
-          <div class="text-yellow-400">
-            <div class="divide-current divide-y-4">
-              <button class="ring-2 p-2 focus:ring-current ring-offset-current ring-offset-2 outline-none">button with ringColor</button>
-              <div>2</div>
-              <div class="text-current">3</div>
-            </div>
+      <div class="text-red-700 border-2 border-current bg-current p-10">
+        <input class="bg-gray-500 text-white placeholder:text-black" placeholder="placeholder color" />
+        <div class="text-yellow-400">
+          <div class="divide-current divide-y-4">
+            <button class="ring-2 p-2 focus:ring-current ring-offset-current ring-offset-2 outline-none">button with ringColor</button>
+            <div>2</div>
+            <div class="text-current">3</div>
           </div>
-          <svg class="stroke-current text-yellow-400 stroke-2">
-            <circle cx="50" cy="50" r="20" />
-          </svg>
-          <svg class="fill-current text-yellow-400 stroke-0">
-            <circle cx="50" cy="50" r="20" />
-          </svg>
-          <div class="bg-gradient-to-r from-red-500 to-current text-green-300 h-20 w-full"></div>
-          <div class="bg-gradient-to-l from-current to-black text-green-300 h-20 w-full"></div>
         </div>
-        `,
+        <svg class="stroke-current text-yellow-400 stroke-2">
+          <circle cx="50" cy="50" r="20" />
+        </svg>
+        <svg class="fill-current text-yellow-400 stroke-0">
+          <circle cx="50" cy="50" r="20" />
+        </svg>
+        <div class="bg-gradient-to-r from-red-500 to-current text-green-300 h-20 w-full"></div>
+        <div class="bg-gradient-to-l from-current to-black text-green-300 h-20 w-full"></div>
+      </div>
+      `,
     },
     {
       code: `
-        <div class="bg-red-600 p-10">
-          <p class="text-yellow-400 border-2 border-green-600 border-t-current p-2">border-t-current</p>
-        </div>
-        `,
+      <div class="bg-red-600 p-10">
+        <p class="text-yellow-400 border-2 border-green-600 border-t-current p-2">border-t-current</p>
+      </div>
+      `,
     },
     {
       code: `
-        <div class="aspect-none">
-          aspect-none is a valid classname
-        </div>`,
+      <div class="aspect-none">
+        aspect-none is a valid classname
+      </div>`,
     },
     {
       code: `
-        <div class="font-mono">
-          font-mono is a valid classname
-        </div>`,
+      <div class="font-mono">
+        font-mono is a valid classname
+      </div>`,
     },
     {
       code: `
-        <div className={'stroke-sky-500/[.1]'}>Arbitrary alpha suffix</div>`,
+      <div className={'stroke-sky-500/[.1]'}>Arbitrary alpha suffix</div>`,
     },
     {
       code: `
-        <div className={'!hidden sm:!flex lg:!block 2xl:!block'}>Important modifier</div>`,
+      <div className={'!hidden sm:!flex lg:!block 2xl:!block'}>Important modifier</div>`,
     },
     {
       code: `
-        <button
-        type="button"
-        className={classnames(
-          "p-2 font-medium",
-          boolVal ? false : "text-black"
-        )}
-        />`,
+      <button
+      type="button"
+      className={classnames(
+        "p-2 font-medium",
+        boolVal ? false : "text-black"
+      )}
+      />`,
     },
     {
       code: `
-        <button
-        type="button"
-        className={classnames(
-          ["p-2 font-medium"],
-          [{"text-black": boolVal}]
-        )}
-        />`,
+      <button
+      type="button"
+      className={classnames(
+        ["p-2 font-medium"],
+        [{"text-black": boolVal}]
+      )}
+      />`,
     },
     {
       code: `
-        <div className="-mt-4">Negative value with custom config</div>`,
+      <div className="-mt-4">Negative value with custom config</div>`,
       options: [
         {
           config: {
@@ -541,11 +541,11 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <div className="transform-none">Disabling transform</div>`,
+      <div className="transform-none">Disabling transform</div>`,
     },
     {
       code: `
-        <div className="p/r[e].f!-x_flex">Nasty prefix</div>`,
+      <div className="p/r[e].f!-x_flex">Nasty prefix</div>`,
       options: [
         {
           config: {
@@ -556,7 +556,7 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <div className="text-9xl text-ffffff/[24%] bg-000000">Issue #101</div>`,
+      <div className="text-9xl text-ffffff/[24%] bg-000000">Issue #101</div>`,
       options: [
         {
           config: {
@@ -573,7 +573,7 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <div className="grid gap-x-4 grid-cols-1fr/minmax(0/360)/1fr">Issue #100</div>`,
+      <div className="grid gap-x-4 grid-cols-1fr/minmax(0/360)/1fr">Issue #100</div>`,
       options: [
         {
           config: {
@@ -591,14 +591,14 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <div class="transform-none">Using</div>
-        <div class="flex flex-col">HTML</div>`,
+      <div class="transform-none">Using</div>
+      <div class="flex flex-col">HTML</div>`,
       parser: require.resolve("@angular-eslint/template-parser"),
     },
     {
       code: `
-        <div class="p/r[e].f!-x_flex">Using HTML</div>
-        <div class="p/r[e].f!-x_block">With nasty prefix</div>`,
+      <div class="p/r[e].f!-x_flex">Using HTML</div>
+      <div class="p/r[e].f!-x_block">With nasty prefix</div>`,
       options: [
         {
           config: {
@@ -610,50 +610,50 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <div class="decoration-clone decoration-slice flex-grow flex-shrink overflow-clip overflow-ellipsis bg-opacity-50 border-opacity-100 transform scale-50">Deprecated classnames yet still supported for now</div>`,
+      <div class="decoration-clone decoration-slice flex-grow flex-shrink overflow-clip overflow-ellipsis bg-opacity-50 border-opacity-100 transform scale-50">Deprecated classnames yet still supported for now</div>`,
     },
     {
       code: `
-        <div class="-ml-[1px] mr-[-1px]">Negative arbitrary value</div>`,
+      <div class="-ml-[1px] mr-[-1px]">Negative arbitrary value</div>`,
     },
     {
       code: `
-        <div className={ctl(\`
-          leading-loose
-          prose
-          md:prose-xl
-          lg:prose-lg
-          lg:prose-h1:text-lg
-          lg:prose-h1:leading-[2.75rem]
-          lg:prose-h2:text-sm
-          lg:prose-h2:leading-[2.125rem]
-          lg:prose-h3:text-xl
-          lg:prose-h3:leading-[1.8125rem]
-          lg:prose-blockquote:py-60
-          lg:prose-blockquote:pr-[5rem]
-          lg:prose-blockquote:pl-[6rem]
-          lg:prose-p:text-xl
-          lg:prose-p:leading-loose
-          dark:prose-headings:text-red-100
-          dark:prose-hr:border-black
-          dark:prose-code:text-pink-100
-          dark:prose-blockquote:text-orange-100
-          dark:prose-a:bg-black
-          dark:prose-a:text-black
-          dark:prose-a:visited:bg-black
-          dark:prose-a:visited:text-teal-200
-          dark:prose-a:hover:bg-black
-          dark:prose-a:hover:text-black
-          dark:prose-a:focus:outline-white
-          dark:prose-thead:bg-purple-500
-          dark:prose-thead:text-black
-          dark:prose-tr:border-b-purple-500
-          dark:prose-pre:bg-[#1f2227]
-          dark:prose-pre:text-[#639bee]
-          dark:prose-li:before:text-green-50
-        \`)}>
-          https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/97
-        </div>`,
+      <div className={ctl(\`
+        leading-loose
+        prose
+        md:prose-xl
+        lg:prose-lg
+        lg:prose-h1:text-lg
+        lg:prose-h1:leading-[2.75rem]
+        lg:prose-h2:text-sm
+        lg:prose-h2:leading-[2.125rem]
+        lg:prose-h3:text-xl
+        lg:prose-h3:leading-[1.8125rem]
+        lg:prose-blockquote:py-60
+        lg:prose-blockquote:pr-[5rem]
+        lg:prose-blockquote:pl-[6rem]
+        lg:prose-p:text-xl
+        lg:prose-p:leading-loose
+        dark:prose-headings:text-red-100
+        dark:prose-hr:border-black
+        dark:prose-code:text-pink-100
+        dark:prose-blockquote:text-orange-100
+        dark:prose-a:bg-black
+        dark:prose-a:text-black
+        dark:prose-a:visited:bg-black
+        dark:prose-a:visited:text-teal-200
+        dark:prose-a:hover:bg-black
+        dark:prose-a:hover:text-black
+        dark:prose-a:focus:outline-white
+        dark:prose-thead:bg-purple-500
+        dark:prose-thead:text-black
+        dark:prose-tr:border-b-purple-500
+        dark:prose-pre:bg-[#1f2227]
+        dark:prose-pre:text-[#639bee]
+        dark:prose-li:before:text-green-50
+      \`)}>
+        https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/97
+      </div>`,
       options: [
         {
           config: {
@@ -664,25 +664,25 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <div class="bg-[#ccc]/[75%] border-t-[#000]/[5]">Issue #130</div>`,
+      <div class="bg-[#ccc]/[75%] border-t-[#000]/[5]">Issue #130</div>`,
     },
     {
       code: `
-        <div class="border-spacing-2">
-          Issue #148
-          https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.1.0
-        </div>`,
+      <div class="border-spacing-2">
+        Issue #148
+        https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.1.0
+      </div>`,
     },
     {
       code: `
-        <div class="prose prose-red prose-xl dark:prose-invert prose-img:rounded-xl prose-headings:underline prose-a:text-blue-600">
-          Support for plugins
-          <p class="not-prose">Not prose</p>
-          <div class="aspect-w-16 aspect-h-9">
-            <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-          </div>
-          <p class="line-clamp-3">Line clamp</p>
-        </div>`,
+      <div class="prose prose-red prose-xl dark:prose-invert prose-img:rounded-xl prose-headings:underline prose-a:text-blue-600">
+        Support for plugins
+        <p class="not-prose">Not prose</p>
+        <div class="aspect-w-16 aspect-h-9">
+          <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+        <p class="line-clamp-3">Line clamp</p>
+      </div>`,
       options: [
         {
           config: {
@@ -697,10 +697,10 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <div>
-          <h1 className="text-red-500">Hello, world!</h1>
-          <button className="btn">Hello</button>
-        </div>`,
+      <div>
+        <h1 className="text-red-500">Hello, world!</h1>
+        <button className="btn">Hello</button>
+      </div>`,
       options: [
         {
           config: {
@@ -711,9 +711,9 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <div class="text-example-1 text-category-example-1">
-          https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/145
-        </div>`,
+      <div class="text-example-1 text-category-example-1">
+        https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/145
+      </div>`,
       options: [
         {
           config: {
@@ -739,11 +739,11 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <div>
-          <div class="bg-fnprimary">PRIMARY using a function</div>
-          <div class="bg-fnsecondary">SECONDARY using a function</div>
-          <p>See https://github.com/adamwathan/tailwind-css-variable-text-opacity-demo</p>
-        </div>`,
+      <div>
+        <div class="bg-fnprimary">PRIMARY using a function</div>
+        <div class="bg-fnsecondary">SECONDARY using a function</div>
+        <p>See https://github.com/adamwathan/tailwind-css-variable-text-opacity-demo</p>
+      </div>`,
       options: [
         {
           config: {
@@ -775,21 +775,21 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-        <div class="grid-flow-dense mix-blend-plus-lighter border-separate border-spacing-4">
-        grid-flow-dense, mix-blend-plus-lighter
-        </div>`,
+      <div class="grid-flow-dense mix-blend-plus-lighter border-separate border-spacing-4">
+      grid-flow-dense, mix-blend-plus-lighter
+      </div>`,
     },
     {
       code: `
-        <div class="
-          border-spacing-y-0
-          border-spacing-px
-          border-spacing-x-1
-          border-spacing-y-2.5
-          border-spacing-96"
-        >
-          border-spacing
-        </div>`,
+      <div class="
+        border-spacing-y-0
+        border-spacing-px
+        border-spacing-x-1
+        border-spacing-y-2.5
+        border-spacing-96"
+      >
+        border-spacing
+      </div>`,
     },
     {
       code: `<div class>No errors while typing</div>`,
@@ -861,37 +861,6 @@ ruleTester.run("no-custom-classname", rule, {
         lg:w-4
       \`);`,
       errors: generateErrors("hello world"),
-    },
-    {
-      code: `
-        cva({
-          variants: {
-            variant: {
-              primary: ["sm:w-6 w-8 container w-12 flex lg:w-4 hello"],
-              primary: ["sm:w-6 w-8 container w-12 flex lg:w-4 world"],
-            },
-          },
-      });
-      `,
-      options: [
-        {
-          callees: ["cva"],
-        },
-      ],
-      errors: generateErrors("hello world"),
-    },
-    {
-      code: `
-        cva({
-          primary: ["sm:w-6 w-8 container w-12 flex lg:w-4 hello"],
-        });
-      `,
-      options: [
-        {
-          callees: ["cva"],
-        },
-      ],
-      errors: generateErrors("hello"),
     },
     {
       code: `<div class="hello tw-container tw-box-content lg_tw-box-border world">Only Tailwind CSS classnames</div>`,
@@ -1102,6 +1071,37 @@ ruleTester.run("no-custom-classname", rule, {
         },
       ],
       errors: generateErrors("bg-404 lg:text-unknown text-color-not-found"),
+    },
+    {
+      code: `
+        cva({
+          variants: {
+            variant: {
+              primary: ["sm:w-6 w-8 container w-12 flex lg:w-4 hello"],
+              primary: ["sm:w-6 w-8 container w-12 flex lg:w-4 world"],
+            },
+          },
+      });
+      `,
+      options: [
+        {
+          callees: ["cva"],
+        },
+      ],
+      errors: generateErrors("hello world"),
+    },
+    {
+      code: `
+        cva({
+          primary: ["sm:w-6 w-8 container w-12 flex lg:w-4 hello"],
+        });
+      `,
+      options: [
+        {
+          callees: ["cva"],
+        },
+      ],
+      errors: generateErrors("hello"),
     },
   ],
 });

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -67,20 +67,20 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <section>
-        <h1>Layout utilities</h1>
-        <div class="container">Container</div>
-        <div class="box-content lg:box-border">Box Sizing</div>
-        <div class="inline-block sm:block md:flex lg:table">Display</div>
-        <div class="float-none sm:float-left md:float-right">Floats</div>
-        <div class="clear-left sm:clear-right md:clear-both lg:clear-none">Clear</div>
-        <div class="isolate sm:isolation-auto">Isolation</div>
-        <div class="object-contain sm:object-cover md:object-fill lg:object-none dark:object-scale-down">Object Fit</div>
-        <div class="overflow-auto sm:overflow-scroll">Overflow</div>
-        <div class="overscroll-none md:overscroll-y-auto">Overscroll Behavior</div>
-        <div class="fixed sm:absolute">Position</div>
-        <div class="visible sm:invisible">Visibility</div>
-      </section>`,
+        <section>
+          <h1>Layout utilities</h1>
+          <div class="container">Container</div>
+          <div class="box-content lg:box-border">Box Sizing</div>
+          <div class="inline-block sm:block md:flex lg:table">Display</div>
+          <div class="float-none sm:float-left md:float-right">Floats</div>
+          <div class="clear-left sm:clear-right md:clear-both lg:clear-none">Clear</div>
+          <div class="isolate sm:isolation-auto">Isolation</div>
+          <div class="object-contain sm:object-cover md:object-fill lg:object-none dark:object-scale-down">Object Fit</div>
+          <div class="overflow-auto sm:overflow-scroll">Overflow</div>
+          <div class="overscroll-none md:overscroll-y-auto">Overscroll Behavior</div>
+          <div class="fixed sm:absolute">Position</div>
+          <div class="visible sm:invisible">Visibility</div>
+        </section>`,
     },
     {
       code: `<div class="columns-2 hover:columns-3 lg:columns-[10rem]">Columns</div>`,
@@ -117,230 +117,230 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <section>
-        <h1>Flexbox & Grid</h1>
-        <div class="basis-[14.2857143%] sm:basis-1">Flex Basis</div>
-        <div class="flex-row">Flex Direction</div>
-        <div class="flex-wrap">Flex Wrap</div>
-        <div class="flex-auto sm:flex-1 flex-[2_2_0%]">Flex</div>
-        <div class="grow sm:grow-0 md:grow-[2]">Flex Grow</div>
-        <div class="shrink sm:shrink-0 md:shrink-[2]">Flex Shrink</div>
-        <div class="order-1 sm:order-[13]">Order</div>
-        <div class="grid-cols-6 sm:grid-cols-[200px_minmax(900px,_1fr)_100px]"></div>
-        <div class="col-auto sm:col-span-1 md:col-[span_1_/_span_3]">Grid Column Start / End</div>
-        <div class="grid-rows-4 sm:grid-rows-[200px_minmax(900px,_1fr)_100px]">Grid Template Rows</div>
-        <div class="row-auto sm:row-span-6 md:row-span-full lg:row-[span_16_/_span_16]">Grid Row Start / End</div>
-        <div class="grid-flow-row-dense">Grid Auto Flow</div>
-        <div class="auto-cols-max sm:auto-cols-[minmax(0,_2fr)]">Grid Auto Columns</div>
-        <div class="auto-rows-max auto-rows-[minmax(0,_2fr)]">Grid Auto Rows</div>
-        <div class="gap-x-0 sm:gap-y-3 gap-[2.75rem]">Gap</div>
-        <div class="justify-end	">Justify Content</div>
-        <div class="justify-items-end	">Justify Items</div>
-        <div class="justify-self-start">Justify Self</div>
-        <div class="content-center">Align Content</div>
-        <div class="items-baseline">Align Items</div>
-        <div class="self-stretch">Align Self</div>
-        <div class="place-content-evenly">Place Content</div>
-        <div class="place-items-center">Place Items</div>
-        <div class="place-self-center">Place Self</div>
-      </section>`,
+        <section>
+          <h1>Flexbox & Grid</h1>
+          <div class="basis-[14.2857143%] sm:basis-1">Flex Basis</div>
+          <div class="flex-row">Flex Direction</div>
+          <div class="flex-wrap">Flex Wrap</div>
+          <div class="flex-auto sm:flex-1 flex-[2_2_0%]">Flex</div>
+          <div class="grow sm:grow-0 md:grow-[2]">Flex Grow</div>
+          <div class="shrink sm:shrink-0 md:shrink-[2]">Flex Shrink</div>
+          <div class="order-1 sm:order-[13]">Order</div>
+          <div class="grid-cols-6 sm:grid-cols-[200px_minmax(900px,_1fr)_100px]"></div>
+          <div class="col-auto sm:col-span-1 md:col-[span_1_/_span_3]">Grid Column Start / End</div>
+          <div class="grid-rows-4 sm:grid-rows-[200px_minmax(900px,_1fr)_100px]">Grid Template Rows</div>
+          <div class="row-auto sm:row-span-6 md:row-span-full lg:row-[span_16_/_span_16]">Grid Row Start / End</div>
+          <div class="grid-flow-row-dense">Grid Auto Flow</div>
+          <div class="auto-cols-max sm:auto-cols-[minmax(0,_2fr)]">Grid Auto Columns</div>
+          <div class="auto-rows-max auto-rows-[minmax(0,_2fr)]">Grid Auto Rows</div>
+          <div class="gap-x-0 sm:gap-y-3 gap-[2.75rem]">Gap</div>
+          <div class="justify-end	">Justify Content</div>
+          <div class="justify-items-end	">Justify Items</div>
+          <div class="justify-self-start">Justify Self</div>
+          <div class="content-center">Align Content</div>
+          <div class="items-baseline">Align Items</div>
+          <div class="self-stretch">Align Self</div>
+          <div class="place-content-evenly">Place Content</div>
+          <div class="place-items-center">Place Items</div>
+          <div class="place-self-center">Place Self</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Spacing</h1>
-        <div class="p-1 sm:pr-0 md:px-[5px]">Padding</div>
-        <div class="m-1 sm:mr-0 md:mx-[5px] lg:-ml-1">Margin</div>
-        <div class="space-x-0 sm:space-y-1 md:space-x-reverse lg:space-y-reverse xl:space-y-[5px] dark:-space-x-1 sm:dark:-space-y-1 xl:dark:space-y-[-5px]">Space Between</div>
-      </section>`,
+        <section>
+          <h1>Spacing</h1>
+          <div class="p-1 sm:pr-0 md:px-[5px]">Padding</div>
+          <div class="m-1 sm:mr-0 md:mx-[5px] lg:-ml-1">Margin</div>
+          <div class="space-x-0 sm:space-y-1 md:space-x-reverse lg:space-y-reverse xl:space-y-[5px] dark:-space-x-1 sm:dark:-space-y-1 xl:dark:space-y-[-5px]">Space Between</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Sizing</h1>
-        <div class="w-0 sm:w-px md:w-1/2 lg:w-max xl:w-[32rem]">Width</div>
-        <div class="min-w-0 sm:min-w-full md:min-w-min lg:min-w-max xl:min-w-[50%]">Min-Width</div>
-        <div class="max-w-0 sm:max-w-none md:max-w-2xl lg:max-w-screen-xl xl:max-w-[50%]">Max-Width</div>
-        <div class="h-0 sm:h-px md:h-1/2 lg:h-max xl:h-[32rem]">Height</div>
-        <div class="min-h-0 sm:min-h-full md:min-h-min lg:min-h-max xl:min-h-[50%]">Min-Height</div>
-        <div class="max-h-0 sm:max-h-2 md:max-h-full lg:max-h-screen xl:max-h-[32rem]">Max-Height</div>
-        <div class=""></div>
-      </section>`,
+        <section>
+          <h1>Sizing</h1>
+          <div class="w-0 sm:w-px md:w-1/2 lg:w-max xl:w-[32rem]">Width</div>
+          <div class="min-w-0 sm:min-w-full md:min-w-min lg:min-w-max xl:min-w-[50%]">Min-Width</div>
+          <div class="max-w-0 sm:max-w-none md:max-w-2xl lg:max-w-screen-xl xl:max-w-[50%]">Max-Width</div>
+          <div class="h-0 sm:h-px md:h-1/2 lg:h-max xl:h-[32rem]">Height</div>
+          <div class="min-h-0 sm:min-h-full md:min-h-min lg:min-h-max xl:min-h-[50%]">Min-Height</div>
+          <div class="max-h-0 sm:max-h-2 md:max-h-full lg:max-h-screen xl:max-h-[32rem]">Max-Height</div>
+          <div class=""></div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Typography</h1>
-        <div class="font-sans sm:font-serif md:font-mono lg:font-['Open_Sans']">Font Family</div>
-        <div class="text-xs sm:text-base md:text-2xl lg:text-[14px]">Font Size</div>
-        <div class="antialiased sm:subpixel-antialiased">Font Smoothing</div>
-        <div class="italic sm:not-italic">Font Style</div>
-        <div class="font-thin sm:font-extralight md:font-light lg:font-normal xl:font-medium dark:font-semibold sm:dark:font-bold md:dark:font-extrabold lg:dark:font-black xl:dark:font-[1100]">Font Weight</div>
-        <div class="ordinal slashed-zero tabular-nums sm:normal-nums md:lining-nums lg:oldstyle-nums xl:proportional-nums 2xl:tabular-nums">Font Variant Numeric</div>
-        <div class="tracking-tighter sm:tracking-tight md:tracking-normal lg:tracking-wide xl:tracking-wider 2xl:tracking-widest dark:tracking-[.25em] sm:dark:-tracking-wide md:dark:-tracking-normal lg:dark:tracking-[-.25em]">Letter Spacing</div>
-        <div class="leading-3 sm:leading-none md:leading-tight lg:leading-snug xl:leading-normal 2xl:leading-relaxed dark:leading-loose sm:dark:leading-[3rem]">Line Height</div>
-        <div class="list-none sm:list-disc md:list-decimal lg:list-[upper-roman]">List Style Type</div>
-        <div class="list-inside sm:list-outside">List Style Position</div>
-        <div class="text-left sm:text-center md:text-right lg:text-justify">Text Alignment</div>
-        <div class="text-inherit sm:text-current md:text-transparent lg:text-black xl:text-white 2xl:text-slate-200 dark:text-[#50d71e] sm:dark:text-[color:var(--yolo)] first:text-black/50 last:text-[#F005] even:text-[#F0F5F6B8] odd:text-[rgba(100,10,140,.5)]">Text Color</div>
-        <div class="underline sm:overline md:line-through lg:no-underline">Text Decoration</div>
-        <div class="decoration-inherit sm:decoration-current md:decoration-transparent lg:text-black xl:decoration-white 2xl:decoration-slate-200 dark:decoration-[#50d71e] sm:dark:decoration-[color:var(--yolo)] first:decoration-black/50 last:decoration-[#F005] even:decoration-[#F0F5F6B8] odd:decoration-[rgba(100,10,140,.5)]">Text Decoration Color</div>
-        <div class="decoration-solid sm:decoration-double md:decoration-dotted lg:decoration-dashed xl:decoration-wavy">Text Decoration Style</div>
-        <div class="decoration-auto sm:decoration-from-font md:decoration-0 lg:decoration-8 xl:decoration-[3px] 2xl:decoration-[length:var(--yolo)]">Text Decoration Thickness</div>
-        <div class="underline-offset-auto sm:underline-offset-0 md:underline-offset-8 underline-offset-[3px]">Text Underline Offset</div>
-        <div class="uppercase sm:lowercase md:capitalize lg:normal-case">Text Transform</div>
-        <div class="truncate sm:text-ellipsis md:text-clip">Text Overflow</div>
-        <div class="indent-0 sm:indent-3 md:indent-[50%] lg:-indent-3 xl:indent-[-10px]">Text Indent</div>
-        <div class="align-baseline sm:align-top md:align-middle lg:align-bottom xl:align-text-top dark:align-text-bottom sm:dark:align-sub md:dark:align-super">Vertical Alignment</div>
-        <div class="whitespace-normal sm:whitespace-nowrap md:whitespace-pre lg:whitespace-pre-line xl:whitespace-pre-wrap">Whitespace</div>
-        <div class="break-normal sm:break-words md:break-all">Word Break</div>
-        <div class="content-none after:content-['_↗'] before:content-[attr(before)] sm:before:content-['Hello_World'] md:before:content-['Hello\_World'] lg:before:content-[url('/icons/link.svg')]">Content</div>
-      </section>`,
+        <section>
+          <h1>Typography</h1>
+          <div class="font-sans sm:font-serif md:font-mono lg:font-['Open_Sans']">Font Family</div>
+          <div class="text-xs sm:text-base md:text-2xl lg:text-[14px]">Font Size</div>
+          <div class="antialiased sm:subpixel-antialiased">Font Smoothing</div>
+          <div class="italic sm:not-italic">Font Style</div>
+          <div class="font-thin sm:font-extralight md:font-light lg:font-normal xl:font-medium dark:font-semibold sm:dark:font-bold md:dark:font-extrabold lg:dark:font-black xl:dark:font-[1100]">Font Weight</div>
+          <div class="ordinal slashed-zero tabular-nums sm:normal-nums md:lining-nums lg:oldstyle-nums xl:proportional-nums 2xl:tabular-nums">Font Variant Numeric</div>
+          <div class="tracking-tighter sm:tracking-tight md:tracking-normal lg:tracking-wide xl:tracking-wider 2xl:tracking-widest dark:tracking-[.25em] sm:dark:-tracking-wide md:dark:-tracking-normal lg:dark:tracking-[-.25em]">Letter Spacing</div>
+          <div class="leading-3 sm:leading-none md:leading-tight lg:leading-snug xl:leading-normal 2xl:leading-relaxed dark:leading-loose sm:dark:leading-[3rem]">Line Height</div>
+          <div class="list-none sm:list-disc md:list-decimal lg:list-[upper-roman]">List Style Type</div>
+          <div class="list-inside sm:list-outside">List Style Position</div>
+          <div class="text-left sm:text-center md:text-right lg:text-justify">Text Alignment</div>
+          <div class="text-inherit sm:text-current md:text-transparent lg:text-black xl:text-white 2xl:text-slate-200 dark:text-[#50d71e] sm:dark:text-[color:var(--yolo)] first:text-black/50 last:text-[#F005] even:text-[#F0F5F6B8] odd:text-[rgba(100,10,140,.5)]">Text Color</div>
+          <div class="underline sm:overline md:line-through lg:no-underline">Text Decoration</div>
+          <div class="decoration-inherit sm:decoration-current md:decoration-transparent lg:text-black xl:decoration-white 2xl:decoration-slate-200 dark:decoration-[#50d71e] sm:dark:decoration-[color:var(--yolo)] first:decoration-black/50 last:decoration-[#F005] even:decoration-[#F0F5F6B8] odd:decoration-[rgba(100,10,140,.5)]">Text Decoration Color</div>
+          <div class="decoration-solid sm:decoration-double md:decoration-dotted lg:decoration-dashed xl:decoration-wavy">Text Decoration Style</div>
+          <div class="decoration-auto sm:decoration-from-font md:decoration-0 lg:decoration-8 xl:decoration-[3px] 2xl:decoration-[length:var(--yolo)]">Text Decoration Thickness</div>
+          <div class="underline-offset-auto sm:underline-offset-0 md:underline-offset-8 underline-offset-[3px]">Text Underline Offset</div>
+          <div class="uppercase sm:lowercase md:capitalize lg:normal-case">Text Transform</div>
+          <div class="truncate sm:text-ellipsis md:text-clip">Text Overflow</div>
+          <div class="indent-0 sm:indent-3 md:indent-[50%] lg:-indent-3 xl:indent-[-10px]">Text Indent</div>
+          <div class="align-baseline sm:align-top md:align-middle lg:align-bottom xl:align-text-top dark:align-text-bottom sm:dark:align-sub md:dark:align-super">Vertical Alignment</div>
+          <div class="whitespace-normal sm:whitespace-nowrap md:whitespace-pre lg:whitespace-pre-line xl:whitespace-pre-wrap">Whitespace</div>
+          <div class="break-normal sm:break-words md:break-all">Word Break</div>
+          <div class="content-none after:content-['_↗'] before:content-[attr(before)] sm:before:content-['Hello_World'] md:before:content-['Hello\_World'] lg:before:content-[url('/icons/link.svg')]">Content</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Backgrounds</h1>
-        <div class="bg-fixed sm:bg-local md:bg-scroll">Background Attachment</div>
-        <div class="bg-clip-border sm:bg-clip-padding md:bg-clip-content lg:bg-clip-text">Background Clip</div>
-        <div class="bg-inherit sm:bg-current md:bg-black lg:bg-lime-900 xl:bg-[#50d71e] 2xl:bg-[color:var(--some)]">Background Color</div>
-        <div class="bg-origin-border sm:bg-origin-padding md:bg-origin-content">Background Origin</div>
-        <div class="bg-bottom sm:bg-center md:bg-left lg:bg-left-bottom xl:bg-left-top 2xl:bg-right dark:bg-right-bottom sm:dark:bg-right-top md:dark:bg-top lg:dark:bg-[center_top_1rem]">Background Position</div>
-        <div class="bg-repeat sm:bg-no-repeat md:bg-repeat-x lg:bg-repeat-y xl:bg-repeat-round 2xl:bg-repeat-space">Background Repeat</div>
-        <div class="bg-auto sm:bg-cover md:bg-contain lg:bg-[length:200px_100px]">Background Size</div>
-        <div class="bg-none sm:bg-gradient-to-tr md:bg-[url('/img/hero-pattern.svg')]">Background Image</div>
-        <div class="from-inherit sm:from-current md:from-transparent lg:from-black xl:from-[#243c5a] 2xl:from-[#243c5a/50] first:from-black/50 last:from-[#F005] even:from-[#F0F5F6B8] odd:from-[rgba(100,10,140,.5)]">Gradient Color Stops</div>
-      </section>`,
+        <section>
+          <h1>Backgrounds</h1>
+          <div class="bg-fixed sm:bg-local md:bg-scroll">Background Attachment</div>
+          <div class="bg-clip-border sm:bg-clip-padding md:bg-clip-content lg:bg-clip-text">Background Clip</div>
+          <div class="bg-inherit sm:bg-current md:bg-black lg:bg-lime-900 xl:bg-[#50d71e] 2xl:bg-[color:var(--some)]">Background Color</div>
+          <div class="bg-origin-border sm:bg-origin-padding md:bg-origin-content">Background Origin</div>
+          <div class="bg-bottom sm:bg-center md:bg-left lg:bg-left-bottom xl:bg-left-top 2xl:bg-right dark:bg-right-bottom sm:dark:bg-right-top md:dark:bg-top lg:dark:bg-[center_top_1rem]">Background Position</div>
+          <div class="bg-repeat sm:bg-no-repeat md:bg-repeat-x lg:bg-repeat-y xl:bg-repeat-round 2xl:bg-repeat-space">Background Repeat</div>
+          <div class="bg-auto sm:bg-cover md:bg-contain lg:bg-[length:200px_100px]">Background Size</div>
+          <div class="bg-none sm:bg-gradient-to-tr md:bg-[url('/img/hero-pattern.svg')]">Background Image</div>
+          <div class="from-inherit sm:from-current md:from-transparent lg:from-black xl:from-[#243c5a] 2xl:from-[#243c5a/50] first:from-black/50 last:from-[#F005] even:from-[#F0F5F6B8] odd:from-[rgba(100,10,140,.5)]">Gradient Color Stops</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Borders</h1>
-        <div class="rounded-none sm:rounded-xl md:rounded-t-md lg:rounded-br-3xl xl:rounded-[12px]">Border Radius</div>
-        <div class="border sm:border-0 md:border-x-2 lg:border-y-8 xl:border-r 2xl:border-t-[3px]">Border Width</div>
-        <div class="border-transparent sm:border-rose-500 md:border-t-indigo-500/75 lg:border-x-indigo-500 xl:border-[#243c5a] first:border-black/50 last:border-[#F005] even:border-[#F0F5F6B8] odd:border-[rgba(100,10,140,.5)]">Border Color</div>
-        <div class="border-solid sm:border-dashed md:border-dotted lg:border-double xl:border-hidden 2xl:border-none">Border Style</div>
-        <div class="divide-y-4 sm:divide-x-8 md:divide-y lg:divide-y-reverse xl:divide-x-reverse 2xl:divide-x-[3px]">Divide Width</div>
-        <div class="divide-gray-400/25 sm:divide-amber-400 md:divide-[#243c5a] first:divide-black/50 last:divide-[#F005] even:divide-[#F0F5F6B8] odd:divide-[rgba(100,10,140,.5)]">Divide Color</div>
-        <div class="divide-solid sm:divide-dashed md:divide-dotted lg:divide-double xl:divide-none">Divide Style</div>
-        <div class="outline-0 sm:outline-4 md:outline-[5px]">Outline Width</div>
-        <div class="outline-inherit sm:outline-current md:outline-black lg:outline-lime-900 xl:outline-[#50d71e] 2xl:outline-[color:var(--some)] first:outline-black/50 last:outline-[#F005] even:outline-[#F0F5F6B8] odd:outline-[rgba(100,10,140,.5)]">Outline Color</div>
-        <div class="outline-none sm:outline md:outline-dashed lg:outline-dotted xl:outline-double 2xl:outline-hidden">Outline Style</div>
-        <div class="outline-offset-4 sm:outline-offset-[3px]">Outline Offset</div>
-        <div class="ring-0 sm:ring-4 md:ring-inset lg:ring-[10px]">Ring Width</div>
-        <div class="ring-inherit sm:ring-current md:ring-black lg:ring-lime-900 xl:ring-[#50d71e] 2xl:ring-[color:var(--some)] first:ring-black/50 last:ring-[#F005] even:ring-[#F0F5F6B8] odd:ring-[rgba(100,10,140,.5)]">Ring Color</div>
-        <div class="ring-offset-4 sm:ring-offset-[3px]">Ring Offset Width</div>
-        <div class="ring-offset-inherit sm:ring-offset-current md:ring-offset-black lg:ring-offset-lime-900 xl:ring-offset-[#50d71e] 2xl:ring-offset-[color:var(--some)] first:ring-offset-black/50 last:ring-offset-[#F005] even:ring-offset-[#F0F5F6B8] odd:ring-offset-[rgba(100,10,140,.5)]">Ring Offset Color</div>
-      </section>`,
+        <section>
+          <h1>Borders</h1>
+          <div class="rounded-none sm:rounded-xl md:rounded-t-md lg:rounded-br-3xl xl:rounded-[12px]">Border Radius</div>
+          <div class="border sm:border-0 md:border-x-2 lg:border-y-8 xl:border-r 2xl:border-t-[3px]">Border Width</div>
+          <div class="border-transparent sm:border-rose-500 md:border-t-indigo-500/75 lg:border-x-indigo-500 xl:border-[#243c5a] first:border-black/50 last:border-[#F005] even:border-[#F0F5F6B8] odd:border-[rgba(100,10,140,.5)]">Border Color</div>
+          <div class="border-solid sm:border-dashed md:border-dotted lg:border-double xl:border-hidden 2xl:border-none">Border Style</div>
+          <div class="divide-y-4 sm:divide-x-8 md:divide-y lg:divide-y-reverse xl:divide-x-reverse 2xl:divide-x-[3px]">Divide Width</div>
+          <div class="divide-gray-400/25 sm:divide-amber-400 md:divide-[#243c5a] first:divide-black/50 last:divide-[#F005] even:divide-[#F0F5F6B8] odd:divide-[rgba(100,10,140,.5)]">Divide Color</div>
+          <div class="divide-solid sm:divide-dashed md:divide-dotted lg:divide-double xl:divide-none">Divide Style</div>
+          <div class="outline-0 sm:outline-4 md:outline-[5px]">Outline Width</div>
+          <div class="outline-inherit sm:outline-current md:outline-black lg:outline-lime-900 xl:outline-[#50d71e] 2xl:outline-[color:var(--some)] first:outline-black/50 last:outline-[#F005] even:outline-[#F0F5F6B8] odd:outline-[rgba(100,10,140,.5)]">Outline Color</div>
+          <div class="outline-none sm:outline md:outline-dashed lg:outline-dotted xl:outline-double 2xl:outline-hidden">Outline Style</div>
+          <div class="outline-offset-4 sm:outline-offset-[3px]">Outline Offset</div>
+          <div class="ring-0 sm:ring-4 md:ring-inset lg:ring-[10px]">Ring Width</div>
+          <div class="ring-inherit sm:ring-current md:ring-black lg:ring-lime-900 xl:ring-[#50d71e] 2xl:ring-[color:var(--some)] first:ring-black/50 last:ring-[#F005] even:ring-[#F0F5F6B8] odd:ring-[rgba(100,10,140,.5)]">Ring Color</div>
+          <div class="ring-offset-4 sm:ring-offset-[3px]">Ring Offset Width</div>
+          <div class="ring-offset-inherit sm:ring-offset-current md:ring-offset-black lg:ring-offset-lime-900 xl:ring-offset-[#50d71e] 2xl:ring-offset-[color:var(--some)] first:ring-offset-black/50 last:ring-offset-[#F005] even:ring-offset-[#F0F5F6B8] odd:ring-offset-[rgba(100,10,140,.5)]">Ring Offset Color</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Effects</h1>
-        <div class="shadow sm:shadow-lg md:shadow-inner lg:shadow-none xl:shadow-[0_35px_60px_-15px_rgba(0,0,0,0.3)]">Box Shadow</div>
-        <div class="shadow-inherit sm:shadow-current md:shadow-black lg:shadow-lime-900 xl:shadow-[#50d71e] 2xl:shadow-[color:var(--some)] first:shadow-black/50 last:shadow-[#F005] even:shadow-[#F0F5F6B8] odd:shadow-[rgba(100,10,140,.5)]">Box Shadow Color</div>
-        <div class="opacity-0 sm:opacity-50 md:opacity-[.67]">Opacity</div>
-        <div class="mix-blend-normal sm:mix-blend-multiply md:mix-blend-screen lg:mix-blend-overlay xl:mix-blend-darken 2xl:mix-blend-lighten dark:mix-blend-color-dodge sm:dark:mix-blend-color-burn md:dark:mix-blend-hard-light lg:dark:mix-blend-soft-light xl:dark:mix-blend-difference 2xl:dark:mix-blend-exclusion hover:mix-blend-hue first:mix-blend-saturation last:mix-blend-color focus:mix-blend-luminosity">Mix Blend Mode</div>
-        <div class="bg-blend-normal sm:bg-blend-multiply md:bg-blend-screen lg:bg-blend-overlay xl:bg-blend-darken 2xl:bg-blend-lighten dark:bg-blend-color-dodge focus:bg-blend-color-burn link:bg-blend-hard-light visited:bg-blend-soft-light hover:bg-blend-difference active:bg-blend-exclusion first:bg-blend-hue last:bg-blend-saturation odd:bg-blend-color even:bg-blend-luminosity">Background Blend Mode</div>
-      </section>`,
+        <section>
+          <h1>Effects</h1>
+          <div class="shadow sm:shadow-lg md:shadow-inner lg:shadow-none xl:shadow-[0_35px_60px_-15px_rgba(0,0,0,0.3)]">Box Shadow</div>
+          <div class="shadow-inherit sm:shadow-current md:shadow-black lg:shadow-lime-900 xl:shadow-[#50d71e] 2xl:shadow-[color:var(--some)] first:shadow-black/50 last:shadow-[#F005] even:shadow-[#F0F5F6B8] odd:shadow-[rgba(100,10,140,.5)]">Box Shadow Color</div>
+          <div class="opacity-0 sm:opacity-50 md:opacity-[.67]">Opacity</div>
+          <div class="mix-blend-normal sm:mix-blend-multiply md:mix-blend-screen lg:mix-blend-overlay xl:mix-blend-darken 2xl:mix-blend-lighten dark:mix-blend-color-dodge sm:dark:mix-blend-color-burn md:dark:mix-blend-hard-light lg:dark:mix-blend-soft-light xl:dark:mix-blend-difference 2xl:dark:mix-blend-exclusion hover:mix-blend-hue first:mix-blend-saturation last:mix-blend-color focus:mix-blend-luminosity">Mix Blend Mode</div>
+          <div class="bg-blend-normal sm:bg-blend-multiply md:bg-blend-screen lg:bg-blend-overlay xl:bg-blend-darken 2xl:bg-blend-lighten dark:bg-blend-color-dodge focus:bg-blend-color-burn link:bg-blend-hard-light visited:bg-blend-soft-light hover:bg-blend-difference active:bg-blend-exclusion first:bg-blend-hue last:bg-blend-saturation odd:bg-blend-color even:bg-blend-luminosity">Background Blend Mode</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Filters</h1>
-        <div class="blur-none sm:blur md:blur-lg lg:blur-[2px]">Blur</div>
-        <div class="brightness-0 sm:brightness-100 md:brightness-[1.75]">Brightness</div>
-        <div class="contrast-0 sm:contrast-100 md:contrast-[.75]">Contrast</div>
-        <div class="drop-shadow sm:drop-shadow-none md:drop-shadow-xl lg:drop-shadow-[0_35px_35px_rgba(0,0,0,0.25)]">Drop Shadow</div>
-        <div class="grayscale sm:grayscale-0 md:grayscale-[50%]">Grayscale</div>
-        <div class="hue-rotate-0 sm:hue-rotate-90 md:-hue-rotate-15 lg:hue-rotate-[270deg] xl:hue-rotate-[-7deg] 2xl:hue-rotate-[var(--yolo)]">Hue Rotate</div>
-        <div class="invert sm:invert-0 md:invert-[.25]">Invert</div>
-        <div class="saturate-0 sm:saturate-150 md:saturate-[.25]">Saturate</div>
-        <div class="sepia-0 sm:sepia md:sepia-[.25]">Sepia</div>
-        <div class="backdrop-blur sm:backdrop-blur-lg md:backdrop-blur-[2px]">Backdrop Blur</div>
-        <div class="backdrop-brightness-50 sm:backdrop-brightness-200 md:backdrop-brightness-[1.75]">Backdrop Brightness</div>
-        <div class="backdrop-contrast-100 sm:backdrop-contrast-0 md:backdrop-contrast-[.25]">Backdrop Contrast</div>
-        <div class="backdrop-grayscale-0 sm:backdrop-grayscale md:backdrop-grayscale-[.5]">Backdrop Grayscale</div>
-        <div class="-backdrop-hue-rotate-15 sm:backdrop-hue-rotate-15 md:backdrop-hue-rotate-[15deg]">Backdrop Hue Rotate</div>
-        <div class="backdrop-invert-0 sm:backdrop-invert md:backdrop-invert-[.25]">Backdrop Invert</div>
-        <div class="backdrop-opacity-50 sm:backdrop-opacity-25 md:backdrop-opacity-[.15]">Backdrop Opacity</div>
-        <div class="backdrop-saturate-150 sm:backdrop-saturate-50 md:backdrop-saturate-[.25]">Backdrop Saturate</div>
-        <div class="backdrop-sepia sm:backdrop-sepia-0 md:backdrop-sepia-[.25]">Backdrop Sepia</div>
-      </section>`,
+        <section>
+          <h1>Filters</h1>
+          <div class="blur-none sm:blur md:blur-lg lg:blur-[2px]">Blur</div>
+          <div class="brightness-0 sm:brightness-100 md:brightness-[1.75]">Brightness</div>
+          <div class="contrast-0 sm:contrast-100 md:contrast-[.75]">Contrast</div>
+          <div class="drop-shadow sm:drop-shadow-none md:drop-shadow-xl lg:drop-shadow-[0_35px_35px_rgba(0,0,0,0.25)]">Drop Shadow</div>
+          <div class="grayscale sm:grayscale-0 md:grayscale-[50%]">Grayscale</div>
+          <div class="hue-rotate-0 sm:hue-rotate-90 md:-hue-rotate-15 lg:hue-rotate-[270deg] xl:hue-rotate-[-7deg] 2xl:hue-rotate-[var(--yolo)]">Hue Rotate</div>
+          <div class="invert sm:invert-0 md:invert-[.25]">Invert</div>
+          <div class="saturate-0 sm:saturate-150 md:saturate-[.25]">Saturate</div>
+          <div class="sepia-0 sm:sepia md:sepia-[.25]">Sepia</div>
+          <div class="backdrop-blur sm:backdrop-blur-lg md:backdrop-blur-[2px]">Backdrop Blur</div>
+          <div class="backdrop-brightness-50 sm:backdrop-brightness-200 md:backdrop-brightness-[1.75]">Backdrop Brightness</div>
+          <div class="backdrop-contrast-100 sm:backdrop-contrast-0 md:backdrop-contrast-[.25]">Backdrop Contrast</div>
+          <div class="backdrop-grayscale-0 sm:backdrop-grayscale md:backdrop-grayscale-[.5]">Backdrop Grayscale</div>
+          <div class="-backdrop-hue-rotate-15 sm:backdrop-hue-rotate-15 md:backdrop-hue-rotate-[15deg]">Backdrop Hue Rotate</div>
+          <div class="backdrop-invert-0 sm:backdrop-invert md:backdrop-invert-[.25]">Backdrop Invert</div>
+          <div class="backdrop-opacity-50 sm:backdrop-opacity-25 md:backdrop-opacity-[.15]">Backdrop Opacity</div>
+          <div class="backdrop-saturate-150 sm:backdrop-saturate-50 md:backdrop-saturate-[.25]">Backdrop Saturate</div>
+          <div class="backdrop-sepia sm:backdrop-sepia-0 md:backdrop-sepia-[.25]">Backdrop Sepia</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Tables</h1>
-        <div class="border-collapse md:border-separate">Border Collapse</div>
-        <div class="table-auto sm:table-fixed">Table Layout</div>
-      </section>`,
+        <section>
+          <h1>Tables</h1>
+          <div class="border-collapse md:border-separate">Border Collapse</div>
+          <div class="table-auto sm:table-fixed">Table Layout</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Transitions & Animation</h1>
-        <div class="transition-none sm:transition-all md:transition lg:transition-colors xl:transition-opacity 2xl:transition-shadow dark:transition-transform first:transition-[height]">Transition Property</div>
-        <div class="duration-100 sm:duration-200 md:duration-[2000ms]">Transition Duration</div>
-        <div class="ease-linear sm:ease-in md:ease-out lg:ease-in-out xl:ease-[cubic-bezier(0.95,0.05,0.795,0.035)]">Transition Timing Function</div>
-        <div class="delay-75 sm:delay-500 md:delay-[2000ms]">Transition Delay</div>
-        <div class="animate-none sm:animate-spin md:animate-ping lg:animate-pulse xl:animate-bounce 2xl:animate-[wiggle_1s_ease-in-out_infinite]">Animation</div>
-      </section>`,
+        <section>
+          <h1>Transitions & Animation</h1>
+          <div class="transition-none sm:transition-all md:transition lg:transition-colors xl:transition-opacity 2xl:transition-shadow dark:transition-transform first:transition-[height]">Transition Property</div>
+          <div class="duration-100 sm:duration-200 md:duration-[2000ms]">Transition Duration</div>
+          <div class="ease-linear sm:ease-in md:ease-out lg:ease-in-out xl:ease-[cubic-bezier(0.95,0.05,0.795,0.035)]">Transition Timing Function</div>
+          <div class="delay-75 sm:delay-500 md:delay-[2000ms]">Transition Delay</div>
+          <div class="animate-none sm:animate-spin md:animate-ping lg:animate-pulse xl:animate-bounce 2xl:animate-[wiggle_1s_ease-in-out_infinite]">Animation</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Transforms</h1>
-        <div class="scale-x-50 sm:scale-y-75 md:scale-0 lg:scale-[1.7] transform-gpu">Scale</div>
-        <div class="rotate-45 sm:-rotate-90 md:rotate-[17deg]">Rotate</div>
-        <div class="translate-x-2.5 sm:translate-y-3 md:-translate-y-10 lg:translate-y-[17rem]">Translate</div>
-        <div class="skew-y-3 skew-x-6 sm:-skew-y-6 md:skew-y-[17deg] lg:skew-y-[-45deg]">Skew</div>
-        <div class="origin-center sm:origin-top md:origin-top-right lg:origin-right xl:origin-bottom-right dark:origin-bottom first:origin-bottom-left last:origin-left odd:origin-top-left even:origin-[33%_75%]">Transform Origin</div>
-      </section>`,
+        <section>
+          <h1>Transforms</h1>
+          <div class="scale-x-50 sm:scale-y-75 md:scale-0 lg:scale-[1.7] transform-gpu">Scale</div>
+          <div class="rotate-45 sm:-rotate-90 md:rotate-[17deg]">Rotate</div>
+          <div class="translate-x-2.5 sm:translate-y-3 md:-translate-y-10 lg:translate-y-[17rem]">Translate</div>
+          <div class="skew-y-3 skew-x-6 sm:-skew-y-6 md:skew-y-[17deg] lg:skew-y-[-45deg]">Skew</div>
+          <div class="origin-center sm:origin-top md:origin-top-right lg:origin-right xl:origin-bottom-right dark:origin-bottom first:origin-bottom-left last:origin-left odd:origin-top-left even:origin-[33%_75%]">Transform Origin</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Interactivity</h1>
-        <div class="accent-emerald-500/25 sm:accent-violet-300 2xl:accent-[#50d71e] first:accent-black/50 last:accent-[#F005] even:accent-[#F0F5F6B8] odd:accent-[rgba(100,10,140,.5)]">Accent Color</div>
-        <div class="appearance-none">Appearance</div>
-        <div class="cursor-auto sm:cursor-default md:cursor-pointer lg:cursor-wait xl:cursor-text 2xl:cursor-move dark:cursor-help sm:dark:cursor-not-allowed md:dark:cursor-none lg:dark:cursor-context-menu xl:dark:cursor-progress 2xl:dark:cursor-cell dark:focus:cursor-crosshair dark:active:cursor-vertical-text dark:valid:cursor-alias first:cursor-copy last:cursor-no-drop even:cursor-grab odd:cursor-grabbing empty:cursor-all-scroll disabled:cursor-col-resize active:cursor-row-resize visited:cursor-n-resize hover:cursor-e-resize focus:cursor-s-resize link:cursor-w-resize only:cursor-ne-resize focus-visible:cursor-nw-resize disabled:cursor-se-resize checked:cursor-sw-resize required:cursor-ew-resize invalid:cursor-ns-resize valid:cursor-nesw-resize in-range:cursor-nwse-resize out-of-range:cursor-zoom-in open:cursor-zoom-out open:first:cursor-[url(hand.cur),_pointer]">Cursor</div>
-        <div class="caret-emerald-500/25 sm:caret-violet-300 2xl:caret-[#50d71e] first:caret-black/50 last:caret-[#F005] even:caret-[#F0F5F6B8] odd:caret-[rgba(100,10,140,.5)]">Caret Color</div>
-        <div class="pointer-events-none sm:pointer-events-auto">Pointer Events</div>
-        <div class="resize-none sm:resize-y md:resize-x lg:resize">Resize</div>
-        <div class="scroll-auto sm:scroll-smooth">Scroll Behavior</div>
-        <div class="scroll-m-0 sm:scroll-mx-px md:scroll-my-0.5 lg:scroll-mb-1 xl:-scroll-mr-1 2xl:scroll-m-[24rem]">Scroll Margin</div>
-        <div class="scroll-p-0 sm:scroll-px-px md:scroll-py-0.5 lg:scroll-pb-1 xl:scroll-pr-1 2xl:scroll-p-[24rem]">Scroll Padding</div>
-        <div class="snap-start sm:snap-end md:snap-center lg:snap-align-none">Scroll Snap Align</div>
-        <div class="snap-normal sm:snap-always">Scroll Snap Stop</div>
-        <div class="snap-none sm:snap-x md:snap-y lg:snap-both xl:snap-mandatory 2xl:snap-proximity">Scroll Snap Type</div>
-        <div class="touch-auto sm:touch-none md:touch-pan-x lg:touch-pan-left xl:touch-pan-right 2xl:touch-pan-y dark::touch-pan-up first:touch-pan-down last:touch-pinch-zoom focus:touch-manipulation">Touch Action</div>
-        <div class="select-none sm:select-text md:select-all lg:select-auto">User Select</div>
-        <div class="will-change-auto sm:will-change-scroll md:will-change-contents lg:will-change-transform">Will Change</div>
-      </section>`,
+        <section>
+          <h1>Interactivity</h1>
+          <div class="accent-emerald-500/25 sm:accent-violet-300 2xl:accent-[#50d71e] first:accent-black/50 last:accent-[#F005] even:accent-[#F0F5F6B8] odd:accent-[rgba(100,10,140,.5)]">Accent Color</div>
+          <div class="appearance-none">Appearance</div>
+          <div class="cursor-auto sm:cursor-default md:cursor-pointer lg:cursor-wait xl:cursor-text 2xl:cursor-move dark:cursor-help sm:dark:cursor-not-allowed md:dark:cursor-none lg:dark:cursor-context-menu xl:dark:cursor-progress 2xl:dark:cursor-cell dark:focus:cursor-crosshair dark:active:cursor-vertical-text dark:valid:cursor-alias first:cursor-copy last:cursor-no-drop even:cursor-grab odd:cursor-grabbing empty:cursor-all-scroll disabled:cursor-col-resize active:cursor-row-resize visited:cursor-n-resize hover:cursor-e-resize focus:cursor-s-resize link:cursor-w-resize only:cursor-ne-resize focus-visible:cursor-nw-resize disabled:cursor-se-resize checked:cursor-sw-resize required:cursor-ew-resize invalid:cursor-ns-resize valid:cursor-nesw-resize in-range:cursor-nwse-resize out-of-range:cursor-zoom-in open:cursor-zoom-out open:first:cursor-[url(hand.cur),_pointer]">Cursor</div>
+          <div class="caret-emerald-500/25 sm:caret-violet-300 2xl:caret-[#50d71e] first:caret-black/50 last:caret-[#F005] even:caret-[#F0F5F6B8] odd:caret-[rgba(100,10,140,.5)]">Caret Color</div>
+          <div class="pointer-events-none sm:pointer-events-auto">Pointer Events</div>
+          <div class="resize-none sm:resize-y md:resize-x lg:resize">Resize</div>
+          <div class="scroll-auto sm:scroll-smooth">Scroll Behavior</div>
+          <div class="scroll-m-0 sm:scroll-mx-px md:scroll-my-0.5 lg:scroll-mb-1 xl:-scroll-mr-1 2xl:scroll-m-[24rem]">Scroll Margin</div>
+          <div class="scroll-p-0 sm:scroll-px-px md:scroll-py-0.5 lg:scroll-pb-1 xl:scroll-pr-1 2xl:scroll-p-[24rem]">Scroll Padding</div>
+          <div class="snap-start sm:snap-end md:snap-center lg:snap-align-none">Scroll Snap Align</div>
+          <div class="snap-normal sm:snap-always">Scroll Snap Stop</div>
+          <div class="snap-none sm:snap-x md:snap-y lg:snap-both xl:snap-mandatory 2xl:snap-proximity">Scroll Snap Type</div>
+          <div class="touch-auto sm:touch-none md:touch-pan-x lg:touch-pan-left xl:touch-pan-right 2xl:touch-pan-y dark::touch-pan-up first:touch-pan-down last:touch-pinch-zoom focus:touch-manipulation">Touch Action</div>
+          <div class="select-none sm:select-text md:select-all lg:select-auto">User Select</div>
+          <div class="will-change-auto sm:will-change-scroll md:will-change-contents lg:will-change-transform">Will Change</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>SVG</h1>
-        <div class="fill-emerald-500 sm:fill-violet-300 2xl:fill-[#50d71e] first:fill-black/50 last:fill-[#F005] even:fill-[#F0F5F6B8] odd:fill-[rgba(100,10,140,.5)]">Fill</div>
-        <div class="stroke-emerald-500 sm:stroke-violet-300 2xl:stroke-[#50d71e] first:stroke-black/50 last:stroke-[#F005] even:stroke-[#F0F5F6B8] odd:stroke-[rgba(100,10,140,.5)]">Stroke</div>
-        <div class="stroke-0 sm:stroke-1 md:stroke-2 lg:stroke-[2px]">Stroke Width</div>
-      </section>`,
+        <section>
+          <h1>SVG</h1>
+          <div class="fill-emerald-500 sm:fill-violet-300 2xl:fill-[#50d71e] first:fill-black/50 last:fill-[#F005] even:fill-[#F0F5F6B8] odd:fill-[rgba(100,10,140,.5)]">Fill</div>
+          <div class="stroke-emerald-500 sm:stroke-violet-300 2xl:stroke-[#50d71e] first:stroke-black/50 last:stroke-[#F005] even:stroke-[#F0F5F6B8] odd:stroke-[rgba(100,10,140,.5)]">Stroke</div>
+          <div class="stroke-0 sm:stroke-1 md:stroke-2 lg:stroke-[2px]">Stroke Width</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Accessibility</h1>
-        <div class="sr-only sm:not-sr-only">Screen Readers</div>
-      </section>`,
+        <section>
+          <h1>Accessibility</h1>
+          <div class="sr-only sm:not-sr-only">Screen Readers</div>
+        </section>`,
     },
     {
       code: `
-      <section>
-        <h1>Official Plugins</h1>
-        <div class=""></div>
-      </section>`,
+        <section>
+          <h1>Official Plugins</h1>
+          <div class=""></div>
+        </section>`,
     },
     {
       code: `<template><div class="container box-content lg:box-border max-h-24 self-end">Only Tailwind CSS classnames</div></template>`,
@@ -349,14 +349,14 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      ctl(\`
-        sm:w-6
-        w-8
-        container
-        w-12
-        flex
-        lg:w-4
-      \`);`,
+        ctl(\`
+          sm:w-6
+          w-8
+          container
+          w-12
+          flex
+          lg:w-4
+        \`);`,
     },
     {
       code: `<div class="tw-container tw-box-content lg_tw-box-border">Only Tailwind CSS classnames</div>`,
@@ -419,16 +419,16 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <div class="group border-indigo-500 hover:bg-white hover:shadow-lg hover:border-transparent">
-      <p class="text-indigo-600 group-hover:text-gray-900">New Project</p>
-      <p class="text-indigo-500 group-hover:text-gray-500">Create a new project from a variety of starting templates.</p>
-      </div>`,
+        <div class="group border-indigo-500 hover:bg-white hover:shadow-lg hover:border-transparent">
+        <p class="text-indigo-600 group-hover:text-gray-900">New Project</p>
+        <p class="text-indigo-500 group-hover:text-gray-500">Create a new project from a variety of starting templates.</p>
+        </div>`,
     },
     {
       code: `
-      <div class="some base white-listed classnames">
-        from css file
-      </div>`,
+        <div class="some base white-listed classnames">
+          from css file
+        </div>`,
       options: [
         {
           cssFiles: ["./tests/**/*.css"],
@@ -437,96 +437,96 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      myTag\`
-        sm:w-6
-        w-8
-        container
-        w-12
-        flex
-        lg:w-4
-      \`;`,
+        myTag\`
+          sm:w-6
+          w-8
+          container
+          w-12
+          flex
+          lg:w-4
+        \`;`,
       options: [{ tags: ["myTag"] }],
     },
     {
       code: `
-      <div class="flex flex-row-reverse space-x-4 space-x-reverse">
-        <div>1</div>
-        <div>2</div>
-        <div>3</div>
-      </div>`,
+        <div class="flex flex-row-reverse space-x-4 space-x-reverse">
+          <div>1</div>
+          <div>2</div>
+          <div>3</div>
+        </div>`,
     },
     {
       code: `
-      <div class="text-red-700 border-2 border-current bg-current p-10">
-        <input class="bg-gray-500 text-white placeholder:text-black" placeholder="placeholder color" />
-        <div class="text-yellow-400">
-          <div class="divide-current divide-y-4">
-            <button class="ring-2 p-2 focus:ring-current ring-offset-current ring-offset-2 outline-none">button with ringColor</button>
-            <div>2</div>
-            <div class="text-current">3</div>
+        <div class="text-red-700 border-2 border-current bg-current p-10">
+          <input class="bg-gray-500 text-white placeholder:text-black" placeholder="placeholder color" />
+          <div class="text-yellow-400">
+            <div class="divide-current divide-y-4">
+              <button class="ring-2 p-2 focus:ring-current ring-offset-current ring-offset-2 outline-none">button with ringColor</button>
+              <div>2</div>
+              <div class="text-current">3</div>
+            </div>
           </div>
+          <svg class="stroke-current text-yellow-400 stroke-2">
+            <circle cx="50" cy="50" r="20" />
+          </svg>
+          <svg class="fill-current text-yellow-400 stroke-0">
+            <circle cx="50" cy="50" r="20" />
+          </svg>
+          <div class="bg-gradient-to-r from-red-500 to-current text-green-300 h-20 w-full"></div>
+          <div class="bg-gradient-to-l from-current to-black text-green-300 h-20 w-full"></div>
         </div>
-        <svg class="stroke-current text-yellow-400 stroke-2">
-          <circle cx="50" cy="50" r="20" />
-        </svg>
-        <svg class="fill-current text-yellow-400 stroke-0">
-          <circle cx="50" cy="50" r="20" />
-        </svg>
-        <div class="bg-gradient-to-r from-red-500 to-current text-green-300 h-20 w-full"></div>
-        <div class="bg-gradient-to-l from-current to-black text-green-300 h-20 w-full"></div>
-      </div>
-      `,
+        `,
     },
     {
       code: `
-      <div class="bg-red-600 p-10">
-        <p class="text-yellow-400 border-2 border-green-600 border-t-current p-2">border-t-current</p>
-      </div>
-      `,
+        <div class="bg-red-600 p-10">
+          <p class="text-yellow-400 border-2 border-green-600 border-t-current p-2">border-t-current</p>
+        </div>
+        `,
     },
     {
       code: `
-      <div class="aspect-none">
-        aspect-none is a valid classname
-      </div>`,
+        <div class="aspect-none">
+          aspect-none is a valid classname
+        </div>`,
     },
     {
       code: `
-      <div class="font-mono">
-        font-mono is a valid classname
-      </div>`,
+        <div class="font-mono">
+          font-mono is a valid classname
+        </div>`,
     },
     {
       code: `
-      <div className={'stroke-sky-500/[.1]'}>Arbitrary alpha suffix</div>`,
+        <div className={'stroke-sky-500/[.1]'}>Arbitrary alpha suffix</div>`,
     },
     {
       code: `
-      <div className={'!hidden sm:!flex lg:!block 2xl:!block'}>Important modifier</div>`,
+        <div className={'!hidden sm:!flex lg:!block 2xl:!block'}>Important modifier</div>`,
     },
     {
       code: `
-      <button
-      type="button"
-      className={classnames(
-        "p-2 font-medium",
-        boolVal ? false : "text-black"
-      )}
-      />`,
+        <button
+        type="button"
+        className={classnames(
+          "p-2 font-medium",
+          boolVal ? false : "text-black"
+        )}
+        />`,
     },
     {
       code: `
-      <button
-      type="button"
-      className={classnames(
-        ["p-2 font-medium"],
-        [{"text-black": boolVal}]
-      )}
-      />`,
+        <button
+        type="button"
+        className={classnames(
+          ["p-2 font-medium"],
+          [{"text-black": boolVal}]
+        )}
+        />`,
     },
     {
       code: `
-      <div className="-mt-4">Negative value with custom config</div>`,
+        <div className="-mt-4">Negative value with custom config</div>`,
       options: [
         {
           config: {
@@ -541,11 +541,11 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <div className="transform-none">Disabling transform</div>`,
+        <div className="transform-none">Disabling transform</div>`,
     },
     {
       code: `
-      <div className="p/r[e].f!-x_flex">Nasty prefix</div>`,
+        <div className="p/r[e].f!-x_flex">Nasty prefix</div>`,
       options: [
         {
           config: {
@@ -556,7 +556,7 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <div className="text-9xl text-ffffff/[24%] bg-000000">Issue #101</div>`,
+        <div className="text-9xl text-ffffff/[24%] bg-000000">Issue #101</div>`,
       options: [
         {
           config: {
@@ -573,7 +573,7 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <div className="grid gap-x-4 grid-cols-1fr/minmax(0/360)/1fr">Issue #100</div>`,
+        <div className="grid gap-x-4 grid-cols-1fr/minmax(0/360)/1fr">Issue #100</div>`,
       options: [
         {
           config: {
@@ -591,14 +591,14 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <div class="transform-none">Using</div>
-      <div class="flex flex-col">HTML</div>`,
+        <div class="transform-none">Using</div>
+        <div class="flex flex-col">HTML</div>`,
       parser: require.resolve("@angular-eslint/template-parser"),
     },
     {
       code: `
-      <div class="p/r[e].f!-x_flex">Using HTML</div>
-      <div class="p/r[e].f!-x_block">With nasty prefix</div>`,
+        <div class="p/r[e].f!-x_flex">Using HTML</div>
+        <div class="p/r[e].f!-x_block">With nasty prefix</div>`,
       options: [
         {
           config: {
@@ -610,50 +610,50 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <div class="decoration-clone decoration-slice flex-grow flex-shrink overflow-clip overflow-ellipsis bg-opacity-50 border-opacity-100 transform scale-50">Deprecated classnames yet still supported for now</div>`,
+        <div class="decoration-clone decoration-slice flex-grow flex-shrink overflow-clip overflow-ellipsis bg-opacity-50 border-opacity-100 transform scale-50">Deprecated classnames yet still supported for now</div>`,
     },
     {
       code: `
-      <div class="-ml-[1px] mr-[-1px]">Negative arbitrary value</div>`,
+        <div class="-ml-[1px] mr-[-1px]">Negative arbitrary value</div>`,
     },
     {
       code: `
-      <div className={ctl(\`
-        leading-loose
-        prose
-        md:prose-xl
-        lg:prose-lg
-        lg:prose-h1:text-lg
-        lg:prose-h1:leading-[2.75rem]
-        lg:prose-h2:text-sm
-        lg:prose-h2:leading-[2.125rem]
-        lg:prose-h3:text-xl
-        lg:prose-h3:leading-[1.8125rem]
-        lg:prose-blockquote:py-60
-        lg:prose-blockquote:pr-[5rem]
-        lg:prose-blockquote:pl-[6rem]
-        lg:prose-p:text-xl
-        lg:prose-p:leading-loose
-        dark:prose-headings:text-red-100
-        dark:prose-hr:border-black
-        dark:prose-code:text-pink-100
-        dark:prose-blockquote:text-orange-100
-        dark:prose-a:bg-black
-        dark:prose-a:text-black
-        dark:prose-a:visited:bg-black
-        dark:prose-a:visited:text-teal-200
-        dark:prose-a:hover:bg-black
-        dark:prose-a:hover:text-black
-        dark:prose-a:focus:outline-white
-        dark:prose-thead:bg-purple-500
-        dark:prose-thead:text-black
-        dark:prose-tr:border-b-purple-500
-        dark:prose-pre:bg-[#1f2227]
-        dark:prose-pre:text-[#639bee]
-        dark:prose-li:before:text-green-50
-      \`)}>
-        https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/97
-      </div>`,
+        <div className={ctl(\`
+          leading-loose
+          prose
+          md:prose-xl
+          lg:prose-lg
+          lg:prose-h1:text-lg
+          lg:prose-h1:leading-[2.75rem]
+          lg:prose-h2:text-sm
+          lg:prose-h2:leading-[2.125rem]
+          lg:prose-h3:text-xl
+          lg:prose-h3:leading-[1.8125rem]
+          lg:prose-blockquote:py-60
+          lg:prose-blockquote:pr-[5rem]
+          lg:prose-blockquote:pl-[6rem]
+          lg:prose-p:text-xl
+          lg:prose-p:leading-loose
+          dark:prose-headings:text-red-100
+          dark:prose-hr:border-black
+          dark:prose-code:text-pink-100
+          dark:prose-blockquote:text-orange-100
+          dark:prose-a:bg-black
+          dark:prose-a:text-black
+          dark:prose-a:visited:bg-black
+          dark:prose-a:visited:text-teal-200
+          dark:prose-a:hover:bg-black
+          dark:prose-a:hover:text-black
+          dark:prose-a:focus:outline-white
+          dark:prose-thead:bg-purple-500
+          dark:prose-thead:text-black
+          dark:prose-tr:border-b-purple-500
+          dark:prose-pre:bg-[#1f2227]
+          dark:prose-pre:text-[#639bee]
+          dark:prose-li:before:text-green-50
+        \`)}>
+          https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/97
+        </div>`,
       options: [
         {
           config: {
@@ -664,25 +664,25 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <div class="bg-[#ccc]/[75%] border-t-[#000]/[5]">Issue #130</div>`,
+        <div class="bg-[#ccc]/[75%] border-t-[#000]/[5]">Issue #130</div>`,
     },
     {
       code: `
-      <div class="border-spacing-2">
-        Issue #148
-        https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.1.0
-      </div>`,
+        <div class="border-spacing-2">
+          Issue #148
+          https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.1.0
+        </div>`,
     },
     {
       code: `
-      <div class="prose prose-red prose-xl dark:prose-invert prose-img:rounded-xl prose-headings:underline prose-a:text-blue-600">
-        Support for plugins
-        <p class="not-prose">Not prose</p>
-        <div class="aspect-w-16 aspect-h-9">
-          <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        </div>
-        <p class="line-clamp-3">Line clamp</p>
-      </div>`,
+        <div class="prose prose-red prose-xl dark:prose-invert prose-img:rounded-xl prose-headings:underline prose-a:text-blue-600">
+          Support for plugins
+          <p class="not-prose">Not prose</p>
+          <div class="aspect-w-16 aspect-h-9">
+            <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          </div>
+          <p class="line-clamp-3">Line clamp</p>
+        </div>`,
       options: [
         {
           config: {
@@ -697,10 +697,10 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <div>
-        <h1 className="text-red-500">Hello, world!</h1>
-        <button className="btn">Hello</button>
-      </div>`,
+        <div>
+          <h1 className="text-red-500">Hello, world!</h1>
+          <button className="btn">Hello</button>
+        </div>`,
       options: [
         {
           config: {
@@ -711,9 +711,9 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <div class="text-example-1 text-category-example-1">
-        https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/145
-      </div>`,
+        <div class="text-example-1 text-category-example-1">
+          https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/145
+        </div>`,
       options: [
         {
           config: {
@@ -739,11 +739,11 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <div>
-        <div class="bg-fnprimary">PRIMARY using a function</div>
-        <div class="bg-fnsecondary">SECONDARY using a function</div>
-        <p>See https://github.com/adamwathan/tailwind-css-variable-text-opacity-demo</p>
-      </div>`,
+        <div>
+          <div class="bg-fnprimary">PRIMARY using a function</div>
+          <div class="bg-fnsecondary">SECONDARY using a function</div>
+          <p>See https://github.com/adamwathan/tailwind-css-variable-text-opacity-demo</p>
+        </div>`,
       options: [
         {
           config: {
@@ -775,21 +775,21 @@ ruleTester.run("no-custom-classname", rule, {
     },
     {
       code: `
-      <div class="grid-flow-dense mix-blend-plus-lighter border-separate border-spacing-4">
-      grid-flow-dense, mix-blend-plus-lighter	
-      </div>`,
+        <div class="grid-flow-dense mix-blend-plus-lighter border-separate border-spacing-4">
+        grid-flow-dense, mix-blend-plus-lighter
+        </div>`,
     },
     {
       code: `
-      <div class="
-        border-spacing-y-0
-        border-spacing-px
-        border-spacing-x-1
-        border-spacing-y-2.5
-        border-spacing-96"
-      >
-        border-spacing
-      </div>`,
+        <div class="
+          border-spacing-y-0
+          border-spacing-px
+          border-spacing-x-1
+          border-spacing-y-2.5
+          border-spacing-96"
+        >
+          border-spacing
+        </div>`,
     },
     {
       code: `<div class>No errors while typing</div>`,
@@ -861,6 +861,37 @@ ruleTester.run("no-custom-classname", rule, {
         lg:w-4
       \`);`,
       errors: generateErrors("hello world"),
+    },
+    {
+      code: `
+        cva({
+          variants: {
+            variant: {
+              primary: ["sm:w-6 w-8 container w-12 flex lg:w-4 hello"],
+              primary: ["sm:w-6 w-8 container w-12 flex lg:w-4 world"],
+            },
+          },
+      });
+      `,
+      options: [
+        {
+          callees: ["cva"],
+        },
+      ],
+      errors: generateErrors("hello world"),
+    },
+    {
+      code: `
+        cva({
+          primary: ["sm:w-6 w-8 container w-12 flex lg:w-4 hello"],
+        });
+      `,
+      options: [
+        {
+          callees: ["cva"],
+        },
+      ],
+      errors: generateErrors("hello"),
     },
     {
       code: `<div class="hello tw-container tw-box-content lg_tw-box-border world">Only Tailwind CSS classnames</div>`,

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -811,6 +811,35 @@ ruleTester.run("no-custom-classname", rule, {
         },
       ],
     },
+    {
+      code: `
+        cva({
+          variants: {
+            variant: {
+              primary: ["sm:w-6 w-8 container w-12 flex lg:w-4"],
+              primary: ["sm:w-6 w-8 container w-12 flex lg:w-4"],
+            },
+          },
+      });
+      `,
+      options: [
+        {
+          callees: ["cva"],
+        },
+      ],
+    },
+    {
+      code: `
+        cva({
+          primary: ["sm:w-6 w-8 container w-12 flex lg:w-4"],
+        });
+      `,
+      options: [
+        {
+          callees: ["cva"],
+        },
+      ],
+    },
   ],
 
   invalid: [


### PR DESCRIPTION


# Support for nested object for custom callees

## Description

This plugin offers support for [classnames](https://www.npmjs.com/package/classnames), a widely used package. But this package handles keys as classnames. This is different then any other plugin like [CVA](https://github.com/joe-bell/cva). 

PR contains a check if the callee is from classnames. Maybe not the best check but only classnames plugin handles this different, so I think it is valid to check for this specific callee. 
Fixes #135

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added two tests in no-custom-className based on custom callee

- [x] no-custom-className (cva nested object)
- [x] no-custom-className (cva simple object)

**Test Configuration**:
* OS + version: e.g. macOS Mojave
* NPM version: 16.14.2
* Node version: 8.5

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings