### PR TITLE
chore:  Move `tailwindcss` to `devDependency` & `peerDependency`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ npm i -D eslint
 Next, install the latest version of `eslint-plugin-tailwindcss` if you are using Tailwind CSS v3
 
 ```
-$ npm i -D eslint-plugin-tailwindcss
+$ npm i -D tailwindcss eslint-plugin-tailwindcss
 ```
 
 > ### Still using Tailwind CSS v2?

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   "files": [
     "lib"
   ],
+  "peerDependencies": {
+    "tailwindcss": "^3.2.2"
+  },
   "dependencies": {
     "fast-glob": "^3.2.5",
-    "postcss": "^8.4.4",
-    "tailwindcss": "^3.2.2"
+    "postcss": "^8.4.4"
   },
   "devDependencies": {
     "@angular-eslint/template-parser": "^13.0.1",
@@ -39,6 +41,7 @@
     "daisyui": "^2.6.4",
     "eslint": "^7.1.0",
     "mocha": "^7.2.0",
+    "tailwindcss": "^3.2.2",
     "typescript": "4.3.5",
     "vue-eslint-parser": "^7.6.0"
   },


### PR DESCRIPTION
## Description

Moves `tailwindcss` to in [./package.json](./package.json) from `dependencies` to:

- `devDependencies` - for developing & testing the plugin
- and to `peerDependencies`, so the projects which use your awesome plugin can install `tailwindcss` on their own, with a certain version.

The installation instructions in the [./README.md](./README.md) also got updated.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

There is no need for testing this, AFAIK.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
