### PR TITLE
fix: #216 `classRegex` ignored in vuejs

### DIFF
--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -244,7 +244,7 @@ module.exports = {
       */
       VAttribute: function (node) {
         switch (true) {
-          case !astUtil.isValidVueAttribute(node):
+          case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
             sortNodeArgumentValue(node, null);

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -188,7 +188,7 @@ module.exports = {
       */
       VAttribute: function (node) {
         switch (true) {
-          case !astUtil.isValidVueAttribute(node):
+          case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
             parseForNegativeArbitraryClassNames(node);

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -421,7 +421,7 @@ module.exports = {
       */
       VAttribute: function (node) {
         switch (true) {
-          case !astUtil.isValidVueAttribute(node):
+          case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
             parseForShorthandCandidates(node);

--- a/lib/rules/migration-from-tailwind-2.js
+++ b/lib/rules/migration-from-tailwind-2.js
@@ -299,7 +299,7 @@ module.exports = {
       */
       VAttribute: function (node) {
         switch (true) {
-          case !astUtil.isValidVueAttribute(node):
+          case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
             parseForObsoleteClassNames(node);

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -188,7 +188,7 @@ module.exports = {
       */
       VAttribute: function (node) {
         switch (true) {
-          case !astUtil.isValidVueAttribute(node):
+          case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
             parseForArbitraryValues(node, null);

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -216,7 +216,7 @@ module.exports = {
       */
       VAttribute: function (node) {
         switch (true) {
-          case !astUtil.isValidVueAttribute(node):
+          case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
             astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true);

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -187,7 +187,7 @@ module.exports = {
       */
       VAttribute: function (node) {
         switch (true) {
-          case !astUtil.isValidVueAttribute(node):
+          case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
             astUtil.parseNodeRecursive(node, null, parseForCustomClassNames);

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -36,25 +36,26 @@ function isClassAttribute(node, classRegex) {
  * Find out if node is `class`
  *
  * @param {ASTNode} node The AST node being checked
+ * @param {String} classRegex Regex to test the attribute that is being checked against
  * @returns {Boolean}
  */
-function isVueClassAttribute(node) {
+function isVueClassAttribute(node, classRegex) {
+  const re = new RegExp(classRegex);
+  let name = '';
   switch (true) {
-    case node.key && /^class$/.test(node.key.name):
+    case node.key && node.key.name && re.test(node.key.name):
       // class="vue-classes-as-litteral"
       return true;
-      break;
     case node.key &&
       node.key.name &&
       node.key.name.name &&
       node.key.argument &&
       node.key.argument.name &&
       /^bind$/.test(node.key.name.name) &&
-      /^class$/.test(node.key.argument.name):
+      re.test(node.key.argument.name):
       // v-bind:class="vue-classes-as-bind"
       // :class="vue-classes-as-bind"
       return true;
-      break;
     default:
       return false;
   }
@@ -154,10 +155,11 @@ function isValidJSXAttribute(node, classRegex) {
  * Find out if the node is a valid candidate for our rules
  *
  * @param {ASTNode} node The AST node being checked
+ * @param {String} classRegex Regex to test the attribute that is being checked against
  * @returns {Boolean}
  */
-function isValidVueAttribute(node) {
-  if (!isVueClassAttribute(node)) {
+function isValidVueAttribute(node, classRegex) {
+  if (!isVueClassAttribute(node, classRegex)) {
     // Only run for class attributes
     return false;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-tailwindcss",
-  "version": "3.10.0",
+  "version": "3.10.1-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-tailwindcss",
-      "version": "3.10.0",
+      "version": "3.10.1-beta.3",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwindcss",
-  "version": "3.10.0",
+  "version": "3.10.1-beta.3",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -1247,5 +1247,25 @@ ruleTester.run("no-custom-classname", rule, {
       code: `<div className="peer-checked/draft:unknown-class">Custom peer name variant with invalid class name</div>`,
       errors: generateErrors("peer-checked/draft:unknown-class"),
     },
+    {
+      code: `<div fooClass="foo" bazClass="baz">Issue #216</div>`,
+      errors: generateErrors("foo baz"),
+      options: [
+        {
+          classRegex: `Class$`,
+        },
+      ],
+    },
+    {
+      code: `<template><div enterActiveClass="foo" enterFromClass="baz">Issue #216</div></template>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+      errors: generateErrors("foo baz"),
+      options: [
+        {
+          classRegex: `class$`,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
# `classRegex` ignored in vuejs

## Description

Fixes #216 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [xI have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
