### PR TITLE
feat: add `ignoredKeys` in settings

### DIFF
--- a/docs/rules/classnames-order.md
+++ b/docs/rules/classnames-order.md
@@ -32,7 +32,7 @@ Examples of **correct** code for this rule:
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva", "tv"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 

--- a/docs/rules/classnames-order.md
+++ b/docs/rules/classnames-order.md
@@ -32,11 +32,18 @@ Examples of **correct** code for this rule:
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 
 For best results, gather the declarative classnames together, avoid mixing conditional classnames in between, move them at the end.
+
+### `ignoredKeys` (default: `["compoundVariants", "defaultVariants"]`)
+
+Using libraries like `cva`, some of its object keys are not meant to contain classnames in its value(s).
+You can specify which key(s) won't be parsed by the plugin using this setting.
+For example, `cva` has `compoundVariants` and `defaultVariants`.
+NB: As `compoundVariants` can have classnames inside its `class` property, you can also use a callee to make sure this inner part gets parsed while its parent is ignored.
 
 ### `config` (default: `"tailwind.config.js"`)
 

--- a/docs/rules/enforces-negative-arbitrary-values.md
+++ b/docs/rules/enforces-negative-arbitrary-values.md
@@ -50,11 +50,18 @@ Examples of **correct** code for this rule:
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 
 For best results, gather the declarative classnames together, avoid mixing conditional classnames in between, move them at the end.
+
+### `ignoredKeys` (default: `["compoundVariants", "defaultVariants"]`)
+
+Using libraries like `cva`, some of its object keys are not meant to contain classnames in its value(s).
+You can specify which key(s) won't be parsed by the plugin using this setting.
+For example, `cva` has `compoundVariants` and `defaultVariants`.
+NB: As `compoundVariants` can have classnames inside its `class` property, you can also use a callee to make sure this inner part gets parsed while its parent is ignored.
 
 ### `config` (default: `"tailwind.config.js"`)
 

--- a/docs/rules/enforces-negative-arbitrary-values.md
+++ b/docs/rules/enforces-negative-arbitrary-values.md
@@ -50,7 +50,7 @@ Examples of **correct** code for this rule:
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva", "tv"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 

--- a/docs/rules/enforces-shorthand.md
+++ b/docs/rules/enforces-shorthand.md
@@ -42,7 +42,7 @@ If indeed, you are using the `classnames-order` rule, then it'll be automaticall
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva", "tv"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 

--- a/docs/rules/enforces-shorthand.md
+++ b/docs/rules/enforces-shorthand.md
@@ -42,11 +42,18 @@ If indeed, you are using the `classnames-order` rule, then it'll be automaticall
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 
 For best results, gather the declarative classnames together, avoid mixing conditional classnames in between, move them at the end.
+
+### `ignoredKeys` (default: `["compoundVariants", "defaultVariants"]`)
+
+Using libraries like `cva`, some of its object keys are not meant to contain classnames in its value(s).
+You can specify which key(s) won't be parsed by the plugin using this setting.
+For example, `cva` has `compoundVariants` and `defaultVariants`.
+NB: As `compoundVariants` can have classnames inside its `class` property, you can also use a callee to make sure this inner part gets parsed while its parent is ignored.
 
 ### `config` (default: `"tailwind.config.js"`)
 

--- a/docs/rules/migration-from-tailwind-2.md
+++ b/docs/rules/migration-from-tailwind-2.md
@@ -87,11 +87,18 @@ This rule will report the issue but **it will not fix it for you**...
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 
 For best results, gather the declarative classnames together, avoid mixing conditional classnames in between, move them at the end.
+
+### `ignoredKeys` (default: `["compoundVariants", "defaultVariants"]`)
+
+Using libraries like `cva`, some of its object keys are not meant to contain classnames in its value(s).
+You can specify which key(s) won't be parsed by the plugin using this setting.
+For example, `cva` has `compoundVariants` and `defaultVariants`.
+NB: As `compoundVariants` can have classnames inside its `class` property, you can also use a callee to make sure this inner part gets parsed while its parent is ignored.
 
 ### `config` (default: `"tailwind.config.js"`)
 

--- a/docs/rules/migration-from-tailwind-2.md
+++ b/docs/rules/migration-from-tailwind-2.md
@@ -87,7 +87,7 @@ This rule will report the issue but **it will not fix it for you**...
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva", "tv"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 

--- a/docs/rules/no-arbitrary-value.md
+++ b/docs/rules/no-arbitrary-value.md
@@ -32,7 +32,7 @@ Examples of **correct** code for this rule:
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva", "tv"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 

--- a/docs/rules/no-arbitrary-value.md
+++ b/docs/rules/no-arbitrary-value.md
@@ -32,11 +32,18 @@ Examples of **correct** code for this rule:
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 
 For best results, gather the declarative classnames together, avoid mixing conditional classnames in between, move them at the end.
+
+### `ignoredKeys` (default: `["compoundVariants", "defaultVariants"]`)
+
+Using libraries like `cva`, some of its object keys are not meant to contain classnames in its value(s).
+You can specify which key(s) won't be parsed by the plugin using this setting.
+For example, `cva` has `compoundVariants` and `defaultVariants`.
+NB: As `compoundVariants` can have classnames inside its `class` property, you can also use a callee to make sure this inner part gets parsed while its parent is ignored.
 
 ### `config` (default: `"tailwind.config.js"`)
 

--- a/docs/rules/no-contradicting-classname.md
+++ b/docs/rules/no-contradicting-classname.md
@@ -32,7 +32,7 @@ Examples of **correct** code for this rule:
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva", "tv"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 

--- a/docs/rules/no-contradicting-classname.md
+++ b/docs/rules/no-contradicting-classname.md
@@ -32,11 +32,18 @@ Examples of **correct** code for this rule:
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 
 For best results, gather the declarative classnames together, avoid mixing conditional classnames in between, move them at the end.
+
+### `ignoredKeys` (default: `["compoundVariants", "defaultVariants"]`)
+
+Using libraries like `cva`, some of its object keys are not meant to contain classnames in its value(s).
+You can specify which key(s) won't be parsed by the plugin using this setting.
+For example, `cva` has `compoundVariants` and `defaultVariants`.
+NB: As `compoundVariants` can have classnames inside its `class` property, you can also use a callee to make sure this inner part gets parsed while its parent is ignored.
 
 ### `config` (default: `"tailwind.config.js"`)
 

--- a/docs/rules/no-custom-classname.md
+++ b/docs/rules/no-custom-classname.md
@@ -34,7 +34,7 @@ Examples of **correct** code for this rule:
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva", "tv"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 

--- a/docs/rules/no-custom-classname.md
+++ b/docs/rules/no-custom-classname.md
@@ -34,11 +34,18 @@ Examples of **correct** code for this rule:
 ...
 ```
 
-### `callees` (default: `["classnames", "clsx", "ctl"]`)
+### `callees` (default: `["classnames", "clsx", "ctl", "cva"]`)
 
 If you use some utility library like [@netlify/classnames-template-literals](https://github.com/netlify/classnames-template-literals), you can add its name to the list to make sure it gets parsed by this rule.
 
 For best results, gather the declarative classnames together, avoid mixing conditional classnames in between, move them at the end.
+
+### `ignoredKeys` (default: `["compoundVariants", "defaultVariants"]`)
+
+Using libraries like `cva`, some of its object keys are not meant to contain classnames in its value(s).
+You can specify which key(s) won't be parsed by the plugin using this setting.
+For example, `cva` has `compoundVariants` and `defaultVariants`.
+NB: As `compoundVariants` can have classnames inside its `class` property, you can also use a callee to make sure this inner part gets parsed while its parent is ignored.
 
 ### `config` (default: `"tailwind.config.js"`)
 

--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -44,6 +44,11 @@ module.exports = {
             items: { type: 'string', minLength: 0 },
             uniqueItems: true,
           },
+          ignoredKeys: {
+            type: 'array',
+            items: { type: 'string', minLength: 0 },
+            uniqueItems: true,
+          },
           config: {
             // default: 'tailwind.config.js',
             type: ['string', 'object'],

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -40,6 +40,11 @@ module.exports = {
             items: { type: 'string', minLength: 0 },
             uniqueItems: true,
           },
+          ignoredKeys: {
+            type: 'array',
+            items: { type: 'string', minLength: 0 },
+            uniqueItems: true,
+          },
           config: {
             // default: 'tailwind.config.js',
             type: ['string', 'object'],

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -41,6 +41,11 @@ module.exports = {
             items: { type: 'string', minLength: 0 },
             uniqueItems: true,
           },
+          ignoredKeys: {
+            type: 'array',
+            items: { type: 'string', minLength: 0 },
+            uniqueItems: true,
+          },
           config: {
             // default: 'tailwind.config.js',
             type: ['string', 'object'],

--- a/lib/rules/migration-from-tailwind-2.js
+++ b/lib/rules/migration-from-tailwind-2.js
@@ -46,6 +46,11 @@ module.exports = {
             items: { type: 'string', minLength: 0 },
             uniqueItems: true,
           },
+          ignoredKeys: {
+            type: 'array',
+            items: { type: 'string', minLength: 0 },
+            uniqueItems: true,
+          },
           config: {
             // default: 'tailwind.config.js',
             type: ['string', 'object'],

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -40,6 +40,11 @@ module.exports = {
             items: { type: 'string', minLength: 0 },
             uniqueItems: true,
           },
+          ignoredKeys: {
+            type: 'array',
+            items: { type: 'string', minLength: 0 },
+            uniqueItems: true,
+          },
           config: {
             // default: 'tailwind.config.js',
             type: ['string', 'object'],

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -41,6 +41,11 @@ module.exports = {
             items: { type: 'string', minLength: 0 },
             uniqueItems: true,
           },
+          ignoredKeys: {
+            type: 'array',
+            items: { type: 'string', minLength: 0 },
+            uniqueItems: true,
+          },
           config: {
             // default: 'tailwind.config.js',
             type: ['string', 'object'],
@@ -57,6 +62,7 @@ module.exports = {
 
   create: function (context) {
     const callees = getOption(context, 'callees');
+    const ignoredKeys = getOption(context, 'ignoredKeys');
     const skipClassAttribute = getOption(context, 'skipClassAttribute');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
@@ -158,9 +164,16 @@ module.exports = {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {
-        astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true);
+        astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true, false, ignoredKeys);
       } else if (node.value && node.value.type === 'JSXExpressionContainer') {
-        astUtil.parseNodeRecursive(node, node.value.expression, parseForContradictingClassNames, true);
+        astUtil.parseNodeRecursive(
+          node,
+          node.value.expression,
+          parseForContradictingClassNames,
+          true,
+          false,
+          ignoredKeys
+        );
       }
     };
 
@@ -180,7 +193,7 @@ module.exports = {
         }
       };
       node.arguments.forEach((arg) => {
-        astUtil.parseNodeRecursive(node, arg, pushClasses, true);
+        astUtil.parseNodeRecursive(node, arg, pushClasses, true, false, ignoredKeys);
       });
       parseForContradictingClassNames(allClassnamesForNode, node);
     };
@@ -204,7 +217,7 @@ module.exports = {
             allClassnamesForNode.push(...classNames);
           }
         };
-        astUtil.parseNodeRecursive(node, node.quasi, pushClasses, true);
+        astUtil.parseNodeRecursive(node, node.quasi, pushClasses, true, false, ignoredKeys);
         parseForContradictingClassNames(allClassnamesForNode, node);
       },
     };
@@ -220,7 +233,7 @@ module.exports = {
           case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
-            astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true);
+            astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true, false, ignoredKeys);
             break;
           case astUtil.isArrayExpression(node):
             const allClassnamesForNode = [];
@@ -234,13 +247,13 @@ module.exports = {
               }
             };
             node.value.expression.elements.forEach((el) => {
-              astUtil.parseNodeRecursive(node, el, pushClasses, true);
+              astUtil.parseNodeRecursive(node, el, pushClasses, true, false, ignoredKeys);
             });
             parseForContradictingClassNames(allClassnamesForNode, node);
             break;
           case astUtil.isObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
-              astUtil.parseNodeRecursive(node, prop, parseForContradictingClassNames);
+              astUtil.parseNodeRecursive(node, prop, parseForContradictingClassNames, false, false, ignoredKeys);
             });
             break;
         }

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -51,6 +51,11 @@ module.exports = {
             items: { type: 'string', minLength: 0 },
             uniqueItems: true,
           },
+          ignoredKeys: {
+            type: 'array',
+            items: { type: 'string', minLength: 0 },
+            uniqueItems: true,
+          },
           config: {
             // default: 'tailwind.config.js',
             type: ['string', 'object'],
@@ -81,6 +86,7 @@ module.exports = {
 
   create: function (context) {
     const callees = getOption(context, 'callees');
+    const ignoredKeys = getOption(context, 'ignoredKeys');
     const skipClassAttribute = getOption(context, 'skipClassAttribute');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
@@ -152,9 +158,9 @@ module.exports = {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {
-        astUtil.parseNodeRecursive(node, null, parseForCustomClassNames);
+        astUtil.parseNodeRecursive(node, null, parseForCustomClassNames, false, false, ignoredKeys);
       } else if (node.value && node.value.type === 'JSXExpressionContainer') {
-        astUtil.parseNodeRecursive(node, node.value.expression, parseForCustomClassNames);
+        astUtil.parseNodeRecursive(node, node.value.expression, parseForCustomClassNames, false, false, ignoredKeys);
       }
     };
 
@@ -164,7 +170,7 @@ module.exports = {
         return;
       }
       node.arguments.forEach((arg) => {
-        astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames);
+        astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames, false, false, ignoredKeys);
       });
     };
 
@@ -176,7 +182,7 @@ module.exports = {
         if (!tags.includes(node.tag.name)) {
           return;
         }
-        astUtil.parseNodeRecursive(node, node.quasi, parseForCustomClassNames);
+        astUtil.parseNodeRecursive(node, node.quasi, parseForCustomClassNames, false, false, ignoredKeys);
       },
     };
 
@@ -191,16 +197,16 @@ module.exports = {
           case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
-            astUtil.parseNodeRecursive(node, null, parseForCustomClassNames);
+            astUtil.parseNodeRecursive(node, null, parseForCustomClassNames, false, false, ignoredKeys);
             break;
           case astUtil.isArrayExpression(node):
             node.value.expression.elements.forEach((arg) => {
-              astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames);
+              astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames, false, false, ignoredKeys);
             });
             break;
           case astUtil.isObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
-              astUtil.parseNodeRecursive(node, prop, parseForCustomClassNames);
+              astUtil.parseNodeRecursive(node, prop, parseForCustomClassNames, false, false, ignoredKeys);
             });
             break;
         }

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -242,9 +242,10 @@ function extractClassnamesFromValue(classStr) {
  * @param {Function} cb The callback function
  * @param {Boolean} skipConditional Optional, indicate distinct parsing for conditional nodes
  * @param {Boolean} isolate Optional, set internally to isolate parsing and validation on conditional children
+ * @param {Array} ignoredKeys Optional, set object keys which should not be parsed e.g. for `cva`
  * @returns {void}
  */
-function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, isolate = false) {
+function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, isolate = false, ignoredKeys = []) {
   // TODO allow vue non litteral
   let originalClassNamesValue;
   let classNames;
@@ -266,39 +267,47 @@ function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, is
     switch (childNode.type) {
       case 'TemplateLiteral':
         childNode.expressions.forEach((exp) => {
-          parseNodeRecursive(rootNode, exp, cb, skipConditional, forceIsolation);
+          parseNodeRecursive(rootNode, exp, cb, skipConditional, forceIsolation, ignoredKeys);
         });
         childNode.quasis.forEach((quasis) => {
-          parseNodeRecursive(rootNode, quasis, cb, skipConditional, isolate);
+          parseNodeRecursive(rootNode, quasis, cb, skipConditional, isolate, ignoredKeys);
         });
         return;
       case 'ConditionalExpression':
-        parseNodeRecursive(rootNode, childNode.consequent, cb, skipConditional, forceIsolation);
-        parseNodeRecursive(rootNode, childNode.alternate, cb, skipConditional, forceIsolation);
+        parseNodeRecursive(rootNode, childNode.consequent, cb, skipConditional, forceIsolation, ignoredKeys);
+        parseNodeRecursive(rootNode, childNode.alternate, cb, skipConditional, forceIsolation, ignoredKeys);
         return;
       case 'LogicalExpression':
-        parseNodeRecursive(rootNode, childNode.right, cb, skipConditional, forceIsolation);
+        parseNodeRecursive(rootNode, childNode.right, cb, skipConditional, forceIsolation, ignoredKeys);
         return;
       case 'ArrayExpression':
         childNode.elements.forEach((el) => {
-          parseNodeRecursive(rootNode, el, cb, skipConditional, forceIsolation);
+          parseNodeRecursive(rootNode, el, cb, skipConditional, forceIsolation, ignoredKeys);
         });
         return;
       case 'ObjectExpression':
         childNode.properties.forEach((prop) => {
           const isUsedByClassNamesPlugin = rootNode.callee && rootNode.callee.name === 'classnames';
+          const isUsedByCVAPlugin = rootNode.callee && rootNode.callee.name === 'cva';
+
+          if (prop.key.type === 'Identifier' && ignoredKeys.includes(prop.key.name)) {
+            // Ignore specific keys defined in settings
+            console.log('SKIPPING prop.key.name: ' + prop.key.name);
+            return;
+          }
 
           parseNodeRecursive(
             rootNode,
             isUsedByClassNamesPlugin ? prop.key : prop.value,
             cb,
             skipConditional,
-            forceIsolation
+            forceIsolation,
+            ignoredKeys
           );
         });
         return;
       case 'Property':
-        parseNodeRecursive(rootNode, childNode.key, cb, skipConditional, forceIsolation);
+        parseNodeRecursive(rootNode, childNode.key, cb, skipConditional, forceIsolation, ignoredKeys);
         return;
       case 'Literal':
         trim = true;

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -288,11 +288,9 @@ function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, is
       case 'ObjectExpression':
         childNode.properties.forEach((prop) => {
           const isUsedByClassNamesPlugin = rootNode.callee && rootNode.callee.name === 'classnames';
-          const isUsedByCVAPlugin = rootNode.callee && rootNode.callee.name === 'cva';
 
           if (prop.key.type === 'Identifier' && ignoredKeys.includes(prop.key.name)) {
             // Ignore specific keys defined in settings
-            console.log('SKIPPING prop.key.name: ' + prop.key.name);
             return;
           }
 

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -13,7 +13,7 @@ function getOption(context, name) {
   // Fallback to defaults
   switch (name) {
     case 'callees':
-      return ['classnames', 'clsx', 'ctl', 'cva'];
+      return ['classnames', 'clsx', 'ctl', 'cva', 'tv'];
     case 'ignoredKeys':
       return ['compoundVariants', 'defaultVariants'];
     case 'classRegex':

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -13,7 +13,9 @@ function getOption(context, name) {
   // Fallback to defaults
   switch (name) {
     case 'callees':
-      return ['classnames', 'clsx', 'ctl'];
+      return ['classnames', 'clsx', 'ctl', 'cva'];
+    case 'ignoredKeys':
+      return ['compoundVariants', 'defaultVariants'];
     case 'classRegex':
       return '^class(Name)?$';
     case 'config':

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-tailwindcss",
-  "version": "3.10.3",
+  "version": "3.11.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-tailwindcss",
-      "version": "3.10.3",
+      "version": "3.11.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwindcss",
-  "version": "3.10.3",
+  "version": "3.11.0-beta.0",
   "description": "Rules enforcing best practices while using Tailwind CSS",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -903,6 +903,44 @@ ruleTester.run("no-custom-classname", rule, {
         },
       ],
     },
+    {
+      code: `
+      // https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/193
+      const button = cva(["font-semibold", "border", "rounded"], {
+        variants: {
+          intent: {
+            primary: "bg-blue-500 text-white border-transparent hover:bg-blue-600",
+            secondary: [
+              "bg-white",
+              "text-gray-800",
+              "border-gray-400",
+              "hover:bg-gray-100",
+            ],
+          },
+          size: {
+            small: ["text-sm", "py-1", "px-2"],
+            medium: ["text-base", "py-2", "px-4"],
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            class: "uppercase",
+          },
+        ],
+        defaultVariants: {
+          intent: "primary",
+          size: "medium",
+        },
+      });
+      `,
+      options: [
+        {
+          callees: ["cva"],
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -1282,6 +1320,39 @@ ruleTester.run("no-custom-classname", rule, {
           classRegex: `class$`,
         },
       ],
+    },
+    {
+      code: `
+      // https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/193
+      const button = cva(["font-semibold", "border", "rounded"], {
+        variants: {
+          intent: {
+            primary: "yolo bg-blue-500 text-white border-transparent hover:bg-blue-600",
+            secondary: "bg-gray-500 text-black",
+          },
+          size: {
+            small: ["text-sm", "py-1", "px-2"],
+            medium: ["text-base", "py-2", "px-4"],
+          },
+        },
+        compoundVariants: [
+          {
+            intent: "primary",
+            size: "medium",
+            class: ctl("custom"),
+          },
+        ],
+        defaultVariants: {
+          intent: "primary",
+        },
+      });
+      `,
+      options: [
+        {
+          callees: ["cva", "ctl"],
+        },
+      ],
+      errors: generateErrors("yolo custom"),
     },
   ],
 });


### PR DESCRIPTION
# Better support for `cva`

## Description

- Add a new setting `ignoredKeys`
- Add `cva` to the default list of `callees`
- Add tests for this new `ignoredKeys` setting

Fixes #193 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tests added in `no-custom-classname`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
