### PR TITLE
fix: do not handle non-ASCII whitespace as separator

### DIFF
--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -217,7 +217,7 @@ function extractClassnamesFromValue(classStr) {
   if (typeof classStr !== 'string') {
     return { classNames: [], whitespaces: [], headSpace: false, tailSpace: false };
   }
-  const separatorRegEx = /(\s+)/;
+  const separatorRegEx = /([\t\n\f\r ]+)/;
   let parts = classStr.split(separatorRegEx);
   if (parts[0] === '') {
     parts.shift();

--- a/lib/util/prettier/order.js
+++ b/lib/util/prettier/order.js
@@ -45,7 +45,7 @@ function sortClasses(classStr, { env, ignoreFirst = false, ignoreLast = false })
   }
 
   let result = '';
-  let parts = classStr.split(/(\s+)/);
+  let parts = classStr.split(/([\t\n\f\r ]+)/);
   let classes = parts.filter((_, i) => i % 2 === 0);
   let whitespace = parts.filter((_, i) => i % 2 !== 0);
 

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -913,7 +913,7 @@ ruleTester.run("classnames-order", rule, {
       code: `
       <template>
         <div v-bind="data" :class="[
-          'py-1.5 font-semibold transition', 
+          'py-1.5 font-semibold transition',
           {
             'text-white': variant === 'white',
             'text-blue-500 hover:text-blue-400 border-blue-500': variant === 'primary',
@@ -924,7 +924,7 @@ ruleTester.run("classnames-order", rule, {
       output: `
       <template>
         <div v-bind="data" :class="[
-          'py-1.5 font-semibold transition', 
+          'py-1.5 font-semibold transition',
           {
             'text-white': variant === 'white',
             'border-blue-500 text-blue-500 hover:text-blue-400': variant === 'primary',
@@ -939,6 +939,11 @@ ruleTester.run("classnames-order", rule, {
     {
       code: `<div class="block group/edit:stroke-0">support named group/peer syntax</div>`,
       output: `<div class="group/edit:stroke-0 block">support named group/peer syntax</div>`,
+      errors: errors,
+    },
+    {
+      code: `<div class="group-hover:edit:stroke-0 py-1\u3000px-2">Do not treat full width space as class separator</div>`,
+      output: `<div class="py-1\u3000px-2 group-hover:edit:stroke-0">Do not treat full width space as class separator</div>`,
       errors: errors,
     },
   ],

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -278,6 +278,9 @@ ruleTester.run("classnames-order", rule, {
       `,
       options: skipClassAttributeOptions,
     },
+    {
+      code: `<div class="py-1\u3000px-2 block">Do not treat full width space as class separator</div>`,
+    },
   ],
   invalid: [
     {
@@ -939,11 +942,6 @@ ruleTester.run("classnames-order", rule, {
     {
       code: `<div class="block group/edit:stroke-0">support named group/peer syntax</div>`,
       output: `<div class="group/edit:stroke-0 block">support named group/peer syntax</div>`,
-      errors: errors,
-    },
-    {
-      code: `<div class="group-hover:edit:stroke-0 py-1\u3000px-2">Do not treat full width space as class separator</div>`,
-      output: `<div class="py-1\u3000px-2 group-hover:edit:stroke-0">Do not treat full width space as class separator</div>`,
       errors: errors,
     },
   ],

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -1354,5 +1354,13 @@ ruleTester.run("no-custom-classname", rule, {
       ],
       errors: generateErrors("yolo custom"),
     },
+    {
+      code: `<div className="px-1\u3000py-2">Full-width space between classes</div>`,
+      errors: generateErrors("px-1\u3000py-2"),
+    },
+    {
+      code: `<div className="\u3000px-1 py-2\u3000">Full-width space before and after classes</div>`,
+      errors: generateErrors("\u3000px-1 py-2\u3000"),
+    },
   ],
 });


### PR DESCRIPTION
# fix: do not handle non-ASCII whitespace as separator

## Description

Fixes #245

This PR improves interpretation of space-separated class names to match the web standards.

Currently any space character `\s` was treated as class separators. However, according to the [relevant spec](https://dom.spec.whatwg.org/#concept-getelementsbyclassname) only [ASCII whitespace](https://infra.spec.whatwg.org/#ascii-whitespace) should be treated as separators.

 See a concrete example and the motivation in the issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] Added failing tests and then updated code to solve the failure

**Test Configuration**:
* OS + version: macOS
* NPM version: 9.5.1
* Node version: 19.8.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] ~Any dependent changes have been merged and published in downstream modules~
- [x] I have checked my code and corrected any misspellings
