### PR TITLE
fix: Parsing spreads in object expressions

### DIFF
--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -289,6 +289,11 @@ function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, is
         childNode.properties.forEach((prop) => {
           const isUsedByClassNamesPlugin = rootNode.callee && rootNode.callee.name === 'classnames';
 
+          if (prop.type === 'SpreadElement') {
+            // Ignore spread elements
+            return;
+          }
+
           if (prop.key.type === 'Identifier' && ignoredKeys.includes(prop.key.name)) {
             // Ignore specific keys defined in settings
             return;

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -985,6 +985,14 @@ ruleTester.run("no-custom-classname", rule, {
         },
       ],
     },
+    {
+      code: `
+        const obj = { a: 12 };
+        <div className={{
+          ...obj
+        }}>Spread inside classname object</div>
+      `,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
# Object expression parsing

## Description

The code inside `ast.js` previously assumed that properties of an `ObjectExpression` ast node would always be a `Property` node, but the spec also allows them to be a `SpreadExpression` ([See here](https://github.com/typescript-eslint/typescript-eslint/blob/3f97eb554a0d928152344f59913f798fd4517b13/packages/ast-spec/src/unions/ObjectLiteralElement.ts#L4))

Fixes #250

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I added a test case with a spread expression inside the `className` property.
As expected this test failed, throwing "TypeError: Cannot read properties of undefined (reading 'type')". After modifying the code inside `ast.js`, this test now passes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
