### PR TITLE
Variable Declarations & Callee Behavior

### DIFF
--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -255,12 +255,12 @@ module.exports = {
           case astUtil.isVLiteralValue(node):
             sortNodeArgumentValue(node, null);
             break;
-          case astUtil.isArrayExpression(node):
+          case astUtil.isVArrayExpression(node):
             node.value.expression.elements.forEach((arg) => {
               sortNodeArgumentValue(node, arg);
             });
             break;
-          case astUtil.isObjectExpression(node):
+          case astUtil.isVObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
               sortNodeArgumentValue(node, prop);
             });

--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -238,7 +238,7 @@ module.exports = {
       if (!astUtil.isValidDeclaratorValue(node)) {
         return;
       }
-      sortNodeArgumentValue(node);
+      sortNodeArgumentValue(node, node.init);
     };
 
     const scriptVisitor = {

--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -8,7 +8,7 @@ const docsUrl = require('../util/docsUrl');
 const customConfig = require('../util/customConfig');
 const astUtil = require('../util/ast');
 const removeDuplicatesFromClassnamesAndWhitespaces = require('../util/removeDuplicatesFromClassnamesAndWhitespaces');
-const getOption = require('../util/settings');
+const { getOption, normalizeCallees } = require('../util/settings');
 const parserUtil = require('../util/parser');
 const order = require('../util/prettier/order');
 const createContextFallback = require('tailwindcss/lib/lib/setupContextUtils').createContext;
@@ -68,12 +68,14 @@ module.exports = {
   },
 
   create: function (context) {
-    const callees = getOption(context, 'callees');
+    const callees = normalizeCallees(getOption(context, 'callees'));
     const skipClassAttribute = getOption(context, 'skipClassAttribute');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
     const removeDuplicates = getOption(context, 'removeDuplicates');
+    const classDeclarationRegex = getOption(context, 'declarationRegex');
+    const skipClassDeclaration = getOption(context, 'skipClassDeclaration');
 
     const mergedConfig = customConfig.resolve(twConfig);
     const contextFallback = // Set the created contextFallback in the cache if it does not exist yet.
@@ -92,7 +94,7 @@ module.exports = {
      * @param {ASTNode} arg The child node of node
      * @returns {void}
      */
-    const sortNodeArgumentValue = (node, arg = null) => {
+    const sortNodeArgumentValue = (node, arg = null, calleeKey = false) => {
       let originalClassNamesValue = null;
       let start = null;
       let end = null;
@@ -114,34 +116,33 @@ module.exports = {
             return;
           case 'TemplateLiteral':
             arg.expressions.forEach((exp) => {
-              sortNodeArgumentValue(node, exp);
+              sortNodeArgumentValue(node, exp, calleeKey);
             });
             arg.quasis.forEach((quasis) => {
-              sortNodeArgumentValue(node, quasis);
+              sortNodeArgumentValue(node, quasis, calleeKey);
             });
             return;
           case 'ConditionalExpression':
-            sortNodeArgumentValue(node, arg.consequent);
-            sortNodeArgumentValue(node, arg.alternate);
+            sortNodeArgumentValue(node, arg.consequent, calleeKey);
+            sortNodeArgumentValue(node, arg.alternate, calleeKey);
             return;
           case 'LogicalExpression':
-            sortNodeArgumentValue(node, arg.right);
+            sortNodeArgumentValue(node, arg.right, calleeKey);
             return;
           case 'ArrayExpression':
             arg.elements.forEach((el) => {
-              sortNodeArgumentValue(node, el);
+              sortNodeArgumentValue(node, el, calleeKey);
             });
             return;
           case 'ObjectExpression':
-            const isUsedByClassNamesPlugin = node.callee && node.callee.name === 'classnames';
             const isVue = node.key && node.key.type === 'VDirectiveKey';
             arg.properties.forEach((prop) => {
-              const propVal = isUsedByClassNamesPlugin || isVue ? prop.key : prop.value;
-              sortNodeArgumentValue(node, propVal);
+              const propVal = calleeKey || isVue ? prop.key : prop.value;
+              sortNodeArgumentValue(node, propVal, calleeKey);
             });
             return;
           case 'Property':
-            sortNodeArgumentValue(node, arg.key);
+            sortNodeArgumentValue(node, arg.key, calleeKey);
             break;
           case 'Literal':
             originalClassNamesValue = arg.value;
@@ -220,20 +221,31 @@ module.exports = {
     };
 
     const callExpressionVisitor = function (node) {
-      const calleeStr = astUtil.calleeToString(node.callee);
-      if (callees.findIndex((name) => calleeStr === name) === -1) {
+      const calleeType = callees[astUtil.calleeToString(node.callee)];
+      if (!calleeType) {
         return;
       }
 
       node.arguments.forEach((arg) => {
-        sortNodeArgumentValue(node, arg);
+        sortNodeArgumentValue(node, arg, calleeType === 'key');
       });
+    };
+
+    const variableDeclaratorVistor = function (node) {
+      if (!astUtil.isVariableDeclaration(node, classDeclarationRegex) || skipClassDeclaration) {
+        return;
+      }
+      if (!astUtil.isValidDeclaratorValue(node)) {
+        return;
+      }
+      sortNodeArgumentValue(node);
     };
 
     const scriptVisitor = {
       JSXAttribute: attributeVisitor,
       TextAttribute: attributeVisitor,
       CallExpression: callExpressionVisitor,
+      VariableDeclarator: variableDeclaratorVistor,
       TaggedTemplateExpression: function (node) {
         if (!tags.includes(node.tag.name)) {
           return;

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -8,7 +8,7 @@ const docsUrl = require('../util/docsUrl');
 const customConfig = require('../util/customConfig');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
-const getOption = require('../util/settings');
+const { getOption, normalizeCallees } = require('../util/settings');
 const parserUtil = require('../util/parser');
 
 //------------------------------------------------------------------------------
@@ -60,11 +60,13 @@ module.exports = {
   },
 
   create: function (context) {
-    const callees = getOption(context, 'callees');
+    const callees = normalizeCallees(getOption(context, 'callees'));
     const skipClassAttribute = getOption(context, 'skipClassAttribute');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
+    const classDeclarationRegex = getOption(context, 'declarationRegex');
+    const skipClassDeclaration = getOption(context, 'skipClassDeclaration');
 
     const mergedConfig = customConfig.resolve(twConfig);
 
@@ -78,7 +80,7 @@ module.exports = {
      * @param {ASTNode} arg The child node of node
      * @returns {void}
      */
-    const parseForNegativeArbitraryClassNames = (node, arg = null) => {
+    const parseForNegativeArbitraryClassNames = (node, arg = null, calleeKey = false) => {
       let originalClassNamesValue = null;
       if (arg === null) {
         originalClassNamesValue = astUtil.extractValueFromNode(node);
@@ -88,34 +90,33 @@ module.exports = {
             return;
           case 'TemplateLiteral':
             arg.expressions.forEach((exp) => {
-              parseForNegativeArbitraryClassNames(node, exp);
+              parseForNegativeArbitraryClassNames(node, exp, calleeKey);
             });
             arg.quasis.forEach((quasis) => {
-              parseForNegativeArbitraryClassNames(node, quasis);
+              parseForNegativeArbitraryClassNames(node, quasis, calleeKey);
             });
             return;
           case 'ConditionalExpression':
-            parseForNegativeArbitraryClassNames(node, arg.consequent);
-            parseForNegativeArbitraryClassNames(node, arg.alternate);
+            parseForNegativeArbitraryClassNames(node, arg.consequent, calleeKey);
+            parseForNegativeArbitraryClassNames(node, arg.alternate, calleeKey);
             return;
           case 'LogicalExpression':
-            parseForNegativeArbitraryClassNames(node, arg.right);
+            parseForNegativeArbitraryClassNames(node, arg.right, calleeKey);
             return;
           case 'ArrayExpression':
             arg.elements.forEach((el) => {
-              parseForNegativeArbitraryClassNames(node, el);
+              parseForNegativeArbitraryClassNames(node, el, calleeKey);
             });
             return;
           case 'ObjectExpression':
-            const isUsedByClassNamesPlugin = node.callee && node.callee.name === 'classnames';
             const isVue = node.key && node.key.type === 'VDirectiveKey';
             arg.properties.forEach((prop) => {
-              const propVal = isUsedByClassNamesPlugin || isVue ? prop.key : prop.value;
-              parseForNegativeArbitraryClassNames(node, propVal);
+              const propVal = calleeKey || isVue ? prop.key : prop.value;
+              parseForNegativeArbitraryClassNames(node, propVal, calleeKey);
             });
             return;
           case 'Property':
-            parseForNegativeArbitraryClassNames(node, arg.key);
+            parseForNegativeArbitraryClassNames(node, arg.key, calleeKey);
             return;
           case 'Literal':
             originalClassNamesValue = arg.value;
@@ -165,19 +166,30 @@ module.exports = {
     };
 
     const callExpressionVisitor = function (node) {
-      const calleeStr = astUtil.calleeToString(node.callee);
-      if (callees.findIndex((name) => calleeStr === name) === -1) {
+      const calleeType = callees[astUtil.calleeToString(node.callee)];
+      if (!calleeType) {
         return;
       }
       node.arguments.forEach((arg) => {
-        parseForNegativeArbitraryClassNames(node, arg);
+        parseForNegativeArbitraryClassNames(node, arg, calleeType === 'key');
       });
+    };
+
+    const variableDeclaratorVistor = function (node) {
+      if (!astUtil.isVariableDeclaration(node, classDeclarationRegex) || skipClassDeclaration) {
+        return;
+      }
+      if (!astUtil.isValidDeclaratorValue(node)) {
+        return;
+      }
+      parseForNegativeArbitraryClassNames(node);
     };
 
     const scriptVisitor = {
       JSXAttribute: attributeVisitor,
       TextAttribute: attributeVisitor,
       CallExpression: callExpressionVisitor,
+      VariableDeclarator: variableDeclaratorVistor,
       TaggedTemplateExpression: function (node) {
         if (!tags.includes(node.tag.name)) {
           return;

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -199,12 +199,12 @@ module.exports = {
           case astUtil.isVLiteralValue(node):
             parseForNegativeArbitraryClassNames(node);
             break;
-          case astUtil.isArrayExpression(node):
+          case astUtil.isVArrayExpression(node):
             node.value.expression.elements.forEach((arg) => {
               parseForNegativeArbitraryClassNames(node, arg);
             });
             break;
-          case astUtil.isObjectExpression(node):
+          case astUtil.isVObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
               parseForNegativeArbitraryClassNames(node, prop);
             });

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -182,7 +182,7 @@ module.exports = {
       if (!astUtil.isValidDeclaratorValue(node)) {
         return;
       }
-      parseForNegativeArbitraryClassNames(node);
+      parseForNegativeArbitraryClassNames(node, node.init);
     };
 
     const scriptVisitor = {

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -461,7 +461,7 @@ module.exports = {
       if (!astUtil.isValidDeclaratorValue(node)) {
         return;
       }
-      parseForShorthandCandidates(node);
+      parseForShorthandCandidates(node, node.init);
     };
 
     const scriptVisitor = {

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -9,7 +9,7 @@ const defaultGroups = require('../config/groups').groups;
 const customConfig = require('../util/customConfig');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
-const getOption = require('../util/settings');
+const { getOption, normalizeCallees } = require('../util/settings');
 const parserUtil = require('../util/parser');
 
 //------------------------------------------------------------------------------
@@ -61,11 +61,13 @@ module.exports = {
   },
 
   create: function (context) {
-    const callees = getOption(context, 'callees');
+    const callees = normalizeCallees(getOption(context, 'callees'));
     const skipClassAttribute = getOption(context, 'skipClassAttribute');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
+    const classDeclarationRegex = getOption(context, 'declarationRegex');
+    const skipClassDeclaration = getOption(context, 'skipClassDeclaration');
 
     const mergedConfig = customConfig.resolve(twConfig);
 
@@ -125,7 +127,7 @@ module.exports = {
      * @param {ASTNode} arg The child node of node
      * @returns {void}
      */
-    const parseForShorthandCandidates = (node, arg = null) => {
+    const parseForShorthandCandidates = (node, arg = null, calleeKey = false) => {
       let originalClassNamesValue = null;
       let start = null;
       let end = null;
@@ -148,34 +150,33 @@ module.exports = {
             return;
           case 'TemplateLiteral':
             arg.expressions.forEach((exp) => {
-              parseForShorthandCandidates(node, exp);
+              parseForShorthandCandidates(node, exp, calleeKey);
             });
             arg.quasis.forEach((quasis) => {
-              parseForShorthandCandidates(node, quasis);
+              parseForShorthandCandidates(node, quasis, calleeKey);
             });
             return;
           case 'ConditionalExpression':
-            parseForShorthandCandidates(node, arg.consequent);
-            parseForShorthandCandidates(node, arg.alternate);
+            parseForShorthandCandidates(node, arg.consequent, calleeKey);
+            parseForShorthandCandidates(node, arg.alternate, calleeKey);
             return;
           case 'LogicalExpression':
-            parseForShorthandCandidates(node, arg.right);
+            parseForShorthandCandidates(node, arg.right, calleeKey);
             return;
           case 'ArrayExpression':
             arg.elements.forEach((el) => {
-              parseForShorthandCandidates(node, el);
+              parseForShorthandCandidates(node, el, calleeKey);
             });
             return;
           case 'ObjectExpression':
-            const isUsedByClassNamesPlugin = node.callee && node.callee.name === 'classnames';
             const isVue = node.key && node.key.type === 'VDirectiveKey';
             arg.properties.forEach((prop) => {
-              const propVal = isUsedByClassNamesPlugin || isVue ? prop.key : prop.value;
-              parseForShorthandCandidates(node, propVal);
+              const propVal = calleeKey || isVue ? prop.key : prop.value;
+              parseForShorthandCandidates(node, propVal, calleeKey);
             });
             return;
           case 'Property':
-            parseForShorthandCandidates(node, arg.key);
+            parseForShorthandCandidates(node, arg.key, calleeKey);
             return;
 
           case 'Literal':
@@ -443,20 +444,31 @@ module.exports = {
     };
 
     const callExpressionVisitor = function (node) {
-      const calleeStr = astUtil.calleeToString(node.callee);
-      if (callees.findIndex((name) => calleeStr === name) === -1) {
+      const calleeType = callees[astUtil.calleeToString(node.callee)];
+      if (!calleeType) {
         return;
       }
 
       node.arguments.forEach((arg) => {
-        parseForShorthandCandidates(node, arg);
+        parseForShorthandCandidates(node, arg, calleeType === 'key');
       });
+    };
+
+    const variableDeclaratorVistor = function (node) {
+      if (!astUtil.isVariableDeclaration(node, classDeclarationRegex) || skipClassDeclaration) {
+        return;
+      }
+      if (!astUtil.isValidDeclaratorValue(node)) {
+        return;
+      }
+      parseForShorthandCandidates(node);
     };
 
     const scriptVisitor = {
       JSXAttribute: attributeVisitor,
       TextAttribute: attributeVisitor,
       CallExpression: callExpressionVisitor,
+      VariableDeclarator: variableDeclaratorVistor,
       TaggedTemplateExpression: function (node) {
         if (!tags.includes(node.tag.name)) {
           return;

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -479,12 +479,12 @@ module.exports = {
           case astUtil.isVLiteralValue(node):
             parseForShorthandCandidates(node);
             break;
-          case astUtil.isArrayExpression(node):
+          case astUtil.isVArrayExpression(node):
             node.value.expression.elements.forEach((arg) => {
               parseForShorthandCandidates(node, arg);
             });
             break;
-          case astUtil.isObjectExpression(node):
+          case astUtil.isVObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
               parseForShorthandCandidates(node, prop);
             });

--- a/lib/rules/migration-from-tailwind-2.js
+++ b/lib/rules/migration-from-tailwind-2.js
@@ -310,12 +310,12 @@ module.exports = {
           case astUtil.isVLiteralValue(node):
             parseForObsoleteClassNames(node);
             break;
-          case astUtil.isArrayExpression(node):
+          case astUtil.isVArrayExpression(node):
             node.value.expression.elements.forEach((arg) => {
               parseForObsoleteClassNames(node, arg);
             });
             break;
-          case astUtil.isObjectExpression(node):
+          case astUtil.isVObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
               parseForObsoleteClassNames(node, prop);
             });

--- a/lib/rules/migration-from-tailwind-2.js
+++ b/lib/rules/migration-from-tailwind-2.js
@@ -8,7 +8,7 @@ const docsUrl = require('../util/docsUrl');
 const customConfig = require('../util/customConfig');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
-const getOption = require('../util/settings');
+const { getOption, normalizeCallees } = require('../util/settings');
 const parserUtil = require('../util/parser');
 
 //------------------------------------------------------------------------------
@@ -66,7 +66,7 @@ module.exports = {
   },
 
   create: function (context) {
-    const callees = getOption(context, 'callees');
+    const callees = normalizeCallees(getOption(context, 'callees'));
     const skipClassAttribute = getOption(context, 'skipClassAttribute');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
@@ -276,8 +276,8 @@ module.exports = {
     };
 
     const callExpressionVisitor = function (node) {
-      const calleeStr = astUtil.calleeToString(node.callee);
-      if (callees.findIndex((name) => calleeStr === name) === -1) {
+      const calleeType = callees[astUtil.calleeToString(node.callee)];
+      if (!calleeType) {
         return;
       }
       node.arguments.forEach((arg) => {

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -182,7 +182,7 @@ module.exports = {
       if (!astUtil.isValidDeclaratorValue(node)) {
         return;
       }
-      parseForArbitraryValues(node);
+      parseForArbitraryValues(node, node.init);
     };
 
     const scriptVisitor = {

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -199,12 +199,12 @@ module.exports = {
           case astUtil.isVLiteralValue(node):
             parseForArbitraryValues(node, null);
             break;
-          case astUtil.isArrayExpression(node):
+          case astUtil.isVArrayExpression(node):
             node.value.expression.elements.forEach((arg) => {
               parseForArbitraryValues(node, arg);
             });
             break;
-          case astUtil.isObjectExpression(node):
+          case astUtil.isVObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
               parseForArbitraryValues(node, prop);
             });

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -8,7 +8,7 @@ const docsUrl = require('../util/docsUrl');
 const customConfig = require('../util/customConfig');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
-const getOption = require('../util/settings');
+const { getOption, normalizeCallees } = require('../util/settings');
 const parserUtil = require('../util/parser');
 
 //------------------------------------------------------------------------------
@@ -60,11 +60,13 @@ module.exports = {
   },
 
   create: function (context) {
-    const callees = getOption(context, 'callees');
+    const callees = normalizeCallees(getOption(context, 'callees'));
     const skipClassAttribute = getOption(context, 'skipClassAttribute');
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
+    const classDeclarationRegex = getOption(context, 'declarationRegex');
+    const skipClassDeclaration = getOption(context, 'skipClassDeclaration');
 
     const mergedConfig = customConfig.resolve(twConfig);
 
@@ -78,7 +80,7 @@ module.exports = {
      * @param {ASTNode} arg The child node of node
      * @returns {void}
      */
-    const parseForArbitraryValues = (node, arg = null) => {
+    const parseForArbitraryValues = (node, arg = null, calleeKey = false) => {
       let originalClassNamesValue = null;
       if (arg === null) {
         originalClassNamesValue = astUtil.extractValueFromNode(node);
@@ -88,34 +90,33 @@ module.exports = {
             return;
           case 'TemplateLiteral':
             arg.expressions.forEach((exp) => {
-              parseForArbitraryValues(node, exp);
+              parseForArbitraryValues(node, exp, calleeKey);
             });
             arg.quasis.forEach((quasis) => {
-              parseForArbitraryValues(node, quasis);
+              parseForArbitraryValues(node, quasis, calleeKey);
             });
             return;
           case 'ConditionalExpression':
-            parseForArbitraryValues(node, arg.consequent);
-            parseForArbitraryValues(node, arg.alternate);
+            parseForArbitraryValues(node, arg.consequent, calleeKey);
+            parseForArbitraryValues(node, arg.alternate, calleeKey);
             return;
           case 'LogicalExpression':
-            parseForArbitraryValues(node, arg.right);
+            parseForArbitraryValues(node, arg.right, calleeKey);
             return;
           case 'ArrayExpression':
             arg.elements.forEach((el) => {
-              parseForArbitraryValues(node, el);
+              parseForArbitraryValues(node, el, calleeKey);
             });
             return;
           case 'ObjectExpression':
-            const isUsedByClassNamesPlugin = node.callee && node.callee.name === 'classnames';
             const isVue = node.key && node.key.type === 'VDirectiveKey';
             arg.properties.forEach((prop) => {
-              const propVal = isUsedByClassNamesPlugin || isVue ? prop.key : prop.value;
-              parseForArbitraryValues(node, propVal);
+              const propVal = calleeKey || isVue ? prop.key : prop.value;
+              parseForArbitraryValues(node, propVal, calleeKey);
             });
             return;
           case 'Property':
-            parseForArbitraryValues(node, arg.key);
+            parseForArbitraryValues(node, arg.key, calleeKey);
             return;
           case 'Literal':
             originalClassNamesValue = arg.value;
@@ -165,19 +166,30 @@ module.exports = {
     };
 
     const callExpressionVisitor = function (node) {
-      const calleeStr = astUtil.calleeToString(node.callee);
-      if (callees.findIndex((name) => calleeStr === name) === -1) {
+      const calleeType = callees[astUtil.calleeToString(node.callee)];
+      if (!calleeType) {
         return;
       }
       node.arguments.forEach((arg) => {
-        parseForArbitraryValues(node, arg);
+        parseForArbitraryValues(node, arg, calleeType === 'key');
       });
+    };
+
+    const variableDeclaratorVistor = function (node) {
+      if (!astUtil.isVariableDeclaration(node, classDeclarationRegex) || skipClassDeclaration) {
+        return;
+      }
+      if (!astUtil.isValidDeclaratorValue(node)) {
+        return;
+      }
+      parseForArbitraryValues(node);
     };
 
     const scriptVisitor = {
       JSXAttribute: attributeVisitor,
       TextAttribute: attributeVisitor,
       CallExpression: callExpressionVisitor,
+      VariableDeclarator: variableDeclaratorVistor,
       TaggedTemplateExpression: function (node) {
         if (!tags.includes(node.tag.name)) {
           return;

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -67,6 +67,8 @@ module.exports = {
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
+    const classDeclarationRegex = getOption(context, 'declarationRegex');
+    const skipClassDeclaration = getOption(context, 'skipClassDeclaration');
 
     const mergedConfig = customConfig.resolve(twConfig);
 
@@ -198,10 +200,21 @@ module.exports = {
       parseForContradictingClassNames(allClassnamesForNode, node);
     };
 
+    const variableDeclaratorVistor = function (node) {
+      if (!astUtil.isClassDeclaration(node, classDeclarationRegex) || skipClassDeclaration) {
+        return;
+      }
+      if (!astUtil.isValidDeclaratorValue(node)) {
+        return;
+      }
+      astUtil.parseNodeRecursive(node, node.init, parseForContradictingClassNames, true, false, ignoredKeys);
+    };
+
     const scriptVisitor = {
       JSXAttribute: attributeVisitor,
       TextAttribute: attributeVisitor,
       CallExpression: callExpressionVisitor,
+      VariableDeclarator: variableDeclaratorVistor,
       TaggedTemplateExpression: function (node) {
         if (!tags.includes(node.tag.name)) {
           return;

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -235,7 +235,7 @@ module.exports = {
           case astUtil.isVLiteralValue(node):
             astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true, false, ignoredKeys);
             break;
-          case astUtil.isArrayExpression(node):
+          case astUtil.isVArrayExpression(node):
             const allClassnamesForNode = [];
             const pushClasses = (classNames, targetNode) => {
               if (targetNode === null) {
@@ -251,7 +251,7 @@ module.exports = {
             });
             parseForContradictingClassNames(allClassnamesForNode, node);
             break;
-          case astUtil.isObjectExpression(node):
+          case astUtil.isVObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
               astUtil.parseNodeRecursive(node, prop, parseForContradictingClassNames, false, false, ignoredKeys);
             });

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -9,7 +9,7 @@ const defaultGroups = require('../config/groups').groups;
 const customConfig = require('../util/customConfig');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
-const getOption = require('../util/settings');
+const { getOption, normalizeCallees } = require('../util/settings');
 const parserUtil = require('../util/parser');
 
 //------------------------------------------------------------------------------
@@ -61,7 +61,7 @@ module.exports = {
   },
 
   create: function (context) {
-    const callees = getOption(context, 'callees');
+    const callees = normalizeCallees(getOption(context, 'callees'));
     const ignoredKeys = getOption(context, 'ignoredKeys');
     const skipClassAttribute = getOption(context, 'skipClassAttribute');
     const tags = getOption(context, 'tags');
@@ -166,7 +166,7 @@ module.exports = {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {
-        astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true, false, ignoredKeys, false);
+        astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true, false, ignoredKeys);
       } else if (node.value && node.value.type === 'JSXExpressionContainer') {
         astUtil.parseNodeRecursive(
           node,
@@ -174,15 +174,14 @@ module.exports = {
           parseForContradictingClassNames,
           true,
           false,
-          ignoredKeys,
-          false
+          ignoredKeys
         );
       }
     };
 
     const callExpressionVisitor = function (node) {
-      const calleeStr = astUtil.calleeToString(node.callee);
-      if (callees.findIndex((name) => calleeStr === name) === -1) {
+      const calleeType = callees[astUtil.calleeToString(node.callee)];
+      if (!calleeType) {
         return;
       }
       const allClassnamesForNode = [];
@@ -196,7 +195,7 @@ module.exports = {
         }
       };
       node.arguments.forEach((arg) => {
-        astUtil.parseNodeRecursive(node, arg, pushClasses, true, false, ignoredKeys, true);
+        astUtil.parseNodeRecursive(node, arg, pushClasses, true, false, ignoredKeys, calleeType === 'key');
       });
       parseForContradictingClassNames(allClassnamesForNode, node);
     };
@@ -208,7 +207,7 @@ module.exports = {
       if (!astUtil.isValidDeclaratorValue(node)) {
         return;
       }
-      astUtil.parseNodeRecursive(node, node.init, parseForContradictingClassNames, true, false, ignoredKeys, false);
+      astUtil.parseNodeRecursive(node, node.init, parseForContradictingClassNames, true, false, ignoredKeys);
     };
 
     const scriptVisitor = {
@@ -231,7 +230,7 @@ module.exports = {
             allClassnamesForNode.push(...classNames);
           }
         };
-        astUtil.parseNodeRecursive(node, node.quasi, pushClasses, true, false, ignoredKeys, false);
+        astUtil.parseNodeRecursive(node, node.quasi, pushClasses, true, false, ignoredKeys);
         parseForContradictingClassNames(allClassnamesForNode, node);
       },
     };
@@ -247,7 +246,7 @@ module.exports = {
           case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
-            astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true, false, ignoredKeys, false);
+            astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true, false, ignoredKeys);
             break;
           case astUtil.isVArrayExpression(node):
             const allClassnamesForNode = [];
@@ -261,13 +260,13 @@ module.exports = {
               }
             };
             node.value.expression.elements.forEach((el) => {
-              astUtil.parseNodeRecursive(node, el, pushClasses, true, false, ignoredKeys, false);
+              astUtil.parseNodeRecursive(node, el, pushClasses, true, false, ignoredKeys);
             });
             parseForContradictingClassNames(allClassnamesForNode, node);
             break;
           case astUtil.isVObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
-              astUtil.parseNodeRecursive(node, prop, parseForContradictingClassNames, false, false, ignoredKeys, false);
+              astUtil.parseNodeRecursive(node, prop, parseForContradictingClassNames, false, false, ignoredKeys);
             });
             break;
         }

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -166,7 +166,7 @@ module.exports = {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {
-        astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true, false, ignoredKeys);
+        astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true, false, ignoredKeys, false);
       } else if (node.value && node.value.type === 'JSXExpressionContainer') {
         astUtil.parseNodeRecursive(
           node,
@@ -174,7 +174,8 @@ module.exports = {
           parseForContradictingClassNames,
           true,
           false,
-          ignoredKeys
+          ignoredKeys,
+          false
         );
       }
     };
@@ -195,7 +196,7 @@ module.exports = {
         }
       };
       node.arguments.forEach((arg) => {
-        astUtil.parseNodeRecursive(node, arg, pushClasses, true, false, ignoredKeys);
+        astUtil.parseNodeRecursive(node, arg, pushClasses, true, false, ignoredKeys, true);
       });
       parseForContradictingClassNames(allClassnamesForNode, node);
     };
@@ -207,7 +208,7 @@ module.exports = {
       if (!astUtil.isValidDeclaratorValue(node)) {
         return;
       }
-      astUtil.parseNodeRecursive(node, node.init, parseForContradictingClassNames, true, false, ignoredKeys);
+      astUtil.parseNodeRecursive(node, node.init, parseForContradictingClassNames, true, false, ignoredKeys, false);
     };
 
     const scriptVisitor = {
@@ -230,7 +231,7 @@ module.exports = {
             allClassnamesForNode.push(...classNames);
           }
         };
-        astUtil.parseNodeRecursive(node, node.quasi, pushClasses, true, false, ignoredKeys);
+        astUtil.parseNodeRecursive(node, node.quasi, pushClasses, true, false, ignoredKeys, false);
         parseForContradictingClassNames(allClassnamesForNode, node);
       },
     };
@@ -246,7 +247,7 @@ module.exports = {
           case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
-            astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true, false, ignoredKeys);
+            astUtil.parseNodeRecursive(node, null, parseForContradictingClassNames, true, false, ignoredKeys, false);
             break;
           case astUtil.isVArrayExpression(node):
             const allClassnamesForNode = [];
@@ -260,13 +261,13 @@ module.exports = {
               }
             };
             node.value.expression.elements.forEach((el) => {
-              astUtil.parseNodeRecursive(node, el, pushClasses, true, false, ignoredKeys);
+              astUtil.parseNodeRecursive(node, el, pushClasses, true, false, ignoredKeys, false);
             });
             parseForContradictingClassNames(allClassnamesForNode, node);
             break;
           case astUtil.isVObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
-              astUtil.parseNodeRecursive(node, prop, parseForContradictingClassNames, false, false, ignoredKeys);
+              astUtil.parseNodeRecursive(node, prop, parseForContradictingClassNames, false, false, ignoredKeys, false);
             });
             break;
         }

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -201,7 +201,7 @@ module.exports = {
     };
 
     const variableDeclaratorVistor = function (node) {
-      if (!astUtil.isClassDeclaration(node, classDeclarationRegex) || skipClassDeclaration) {
+      if (!astUtil.isVariableDeclaration(node, classDeclarationRegex) || skipClassDeclaration) {
         return;
       }
       if (!astUtil.isValidDeclaratorValue(node)) {

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -180,7 +180,7 @@ module.exports = {
     };
 
     const variableDeclaratorVistor = function (node) {
-      if (!astUtil.isClassDeclaration(node, classDeclarationRegex) || skipClassDeclaration) {
+      if (!astUtil.isVariableDeclaration(node, classDeclarationRegex) || skipClassDeclaration) {
         return;
       }
       if (!astUtil.isValidDeclaratorValue(node)) {

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -9,7 +9,7 @@ const defaultGroups = require('../config/groups').groups;
 const customConfig = require('../util/customConfig');
 const astUtil = require('../util/ast');
 const groupUtil = require('../util/groupMethods');
-const getOption = require('../util/settings');
+const { getOption, normalizeCallees } = require('../util/settings');
 const parserUtil = require('../util/parser');
 const getClassnamesFromCSS = require('../util/cssFiles');
 const createContextFallback = require('tailwindcss/lib/lib/setupContextUtils').createContext;
@@ -49,7 +49,7 @@ module.exports = {
         type: 'object',
         properties: {
           callees: {
-            type: 'array',
+            type: ['array', 'object'],
             items: { type: 'string', minLength: 0 },
             uniqueItems: true,
           },
@@ -87,7 +87,7 @@ module.exports = {
   },
 
   create: function (context) {
-    const callees = getOption(context, 'callees');
+    const callees = normalizeCallees(getOption(context, 'callees'));
     const ignoredKeys = getOption(context, 'ignoredKeys');
     const skipClassAttribute = getOption(context, 'skipClassAttribute');
     const tags = getOption(context, 'tags');
@@ -163,19 +163,19 @@ module.exports = {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {
-        astUtil.parseNodeRecursive(node, null, parseForCustomClassNames, false, false, ignoredKeys, false);
+        astUtil.parseNodeRecursive(node, null, parseForCustomClassNames, false, false, ignoredKeys);
       } else if (node.value && node.value.type === 'JSXExpressionContainer') {
-        astUtil.parseNodeRecursive(node, node.value.expression, parseForCustomClassNames, false, false, ignoredKeys, false);
+        astUtil.parseNodeRecursive(node, node.value.expression, parseForCustomClassNames, false, false, ignoredKeys);
       }
     };
 
     const callExpressionVisitor = function (node) {
-      const calleeStr = astUtil.calleeToString(node.callee);
-      if (callees.findIndex((name) => calleeStr === name) === -1) {
+      const calleeType = callees[astUtil.calleeToString(node.callee)];
+      if (!calleeType) {
         return;
       }
       node.arguments.forEach((arg) => {
-        astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames, false, false, ignoredKeys, true);
+        astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames, false, false, ignoredKeys, calleeType === 'key');
       });
     };
 
@@ -186,7 +186,7 @@ module.exports = {
       if (!astUtil.isValidDeclaratorValue(node)) {
         return;
       }
-      astUtil.parseNodeRecursive(node, node.init, parseForCustomClassNames, false, false, ignoredKeys, false);
+      astUtil.parseNodeRecursive(node, node.init, parseForCustomClassNames, false, false, ignoredKeys);
     };
 
     const scriptVisitor = {
@@ -198,7 +198,7 @@ module.exports = {
         if (!tags.includes(node.tag.name)) {
           return;
         }
-        astUtil.parseNodeRecursive(node, node.quasi, parseForCustomClassNames, false, false, ignoredKeys, false);
+        astUtil.parseNodeRecursive(node, node.quasi, parseForCustomClassNames, false, false, ignoredKeys);
       },
     };
 
@@ -213,16 +213,16 @@ module.exports = {
           case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
-            astUtil.parseNodeRecursive(node, null, parseForCustomClassNames, false, false, ignoredKeys, false);
+            astUtil.parseNodeRecursive(node, null, parseForCustomClassNames, false, false, ignoredKeys);
             break;
           case astUtil.isVArrayExpression(node):
             node.value.expression.elements.forEach((arg) => {
-              astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames, false, false, ignoredKeys, false);
+              astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames, false, false, ignoredKeys);
             });
             break;
           case astUtil.isVObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
-              astUtil.parseNodeRecursive(node, prop, parseForCustomClassNames, false, false, ignoredKeys, false);
+              astUtil.parseNodeRecursive(node, prop, parseForCustomClassNames, false, false, ignoredKeys);
             });
             break;
         }

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -96,6 +96,8 @@ module.exports = {
     const cssFilesRefreshRate = getOption(context, 'cssFilesRefreshRate');
     const whitelist = getOption(context, 'whitelist');
     const classRegex = getOption(context, 'classRegex');
+    const classDeclarationRegex = getOption(context, 'declarationRegex');
+    const skipClassDeclaration = getOption(context, 'skipClassDeclaration');
 
     const mergedConfig = customConfig.resolve(twConfig);
     const contextFallback = // Set the created contextFallback in the cache if it does not exist yet.
@@ -177,10 +179,21 @@ module.exports = {
       });
     };
 
+    const variableDeclaratorVistor = function (node) {
+      if (!astUtil.isClassDeclaration(node, classDeclarationRegex) || skipClassDeclaration) {
+        return;
+      }
+      if (!astUtil.isValidDeclaratorValue(node)) {
+        return;
+      }
+      astUtil.parseNodeRecursive(node, node.init, parseForCustomClassNames, false, false, ignoredKeys);
+    };
+
     const scriptVisitor = {
       JSXAttribute: attributeVisitor,
       TextAttribute: attributeVisitor,
       CallExpression: callExpressionVisitor,
+      VariableDeclarator: variableDeclaratorVistor,
       TaggedTemplateExpression: function (node) {
         if (!tags.includes(node.tag.name)) {
           return;

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -163,9 +163,9 @@ module.exports = {
         return;
       }
       if (astUtil.isLiteralAttributeValue(node)) {
-        astUtil.parseNodeRecursive(node, null, parseForCustomClassNames, false, false, ignoredKeys);
+        astUtil.parseNodeRecursive(node, null, parseForCustomClassNames, false, false, ignoredKeys, false);
       } else if (node.value && node.value.type === 'JSXExpressionContainer') {
-        astUtil.parseNodeRecursive(node, node.value.expression, parseForCustomClassNames, false, false, ignoredKeys);
+        astUtil.parseNodeRecursive(node, node.value.expression, parseForCustomClassNames, false, false, ignoredKeys, false);
       }
     };
 
@@ -175,7 +175,7 @@ module.exports = {
         return;
       }
       node.arguments.forEach((arg) => {
-        astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames, false, false, ignoredKeys);
+        astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames, false, false, ignoredKeys, true);
       });
     };
 
@@ -186,7 +186,7 @@ module.exports = {
       if (!astUtil.isValidDeclaratorValue(node)) {
         return;
       }
-      astUtil.parseNodeRecursive(node, node.init, parseForCustomClassNames, false, false, ignoredKeys);
+      astUtil.parseNodeRecursive(node, node.init, parseForCustomClassNames, false, false, ignoredKeys, false);
     };
 
     const scriptVisitor = {
@@ -198,7 +198,7 @@ module.exports = {
         if (!tags.includes(node.tag.name)) {
           return;
         }
-        astUtil.parseNodeRecursive(node, node.quasi, parseForCustomClassNames, false, false, ignoredKeys);
+        astUtil.parseNodeRecursive(node, node.quasi, parseForCustomClassNames, false, false, ignoredKeys, false);
       },
     };
 
@@ -213,16 +213,16 @@ module.exports = {
           case !astUtil.isValidVueAttribute(node, classRegex):
             return;
           case astUtil.isVLiteralValue(node):
-            astUtil.parseNodeRecursive(node, null, parseForCustomClassNames, false, false, ignoredKeys);
+            astUtil.parseNodeRecursive(node, null, parseForCustomClassNames, false, false, ignoredKeys, false);
             break;
           case astUtil.isVArrayExpression(node):
             node.value.expression.elements.forEach((arg) => {
-              astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames, false, false, ignoredKeys);
+              astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames, false, false, ignoredKeys, false);
             });
             break;
           case astUtil.isVObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
-              astUtil.parseNodeRecursive(node, prop, parseForCustomClassNames, false, false, ignoredKeys);
+              astUtil.parseNodeRecursive(node, prop, parseForCustomClassNames, false, false, ignoredKeys, false);
             });
             break;
         }

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -202,12 +202,12 @@ module.exports = {
           case astUtil.isVLiteralValue(node):
             astUtil.parseNodeRecursive(node, null, parseForCustomClassNames, false, false, ignoredKeys);
             break;
-          case astUtil.isArrayExpression(node):
+          case astUtil.isVArrayExpression(node):
             node.value.expression.elements.forEach((arg) => {
               astUtil.parseNodeRecursive(node, arg, parseForCustomClassNames, false, false, ignoredKeys);
             });
             break;
-          case astUtil.isObjectExpression(node):
+          case astUtil.isVObjectExpression(node):
             node.value.expression.properties.forEach((prop) => {
               astUtil.parseNodeRecursive(node, prop, parseForCustomClassNames, false, false, ignoredKeys);
             });

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -43,6 +43,28 @@ function isClassAttribute(node, classRegex) {
 }
 
 /**
+ * Find out if node is a class variable declaration
+ *
+ * @param {ASTNode} node The AST node being checked
+ * @param {String} classDeclarationRegex Regex to test the attribute that is being checked against
+ * @returns {Boolean}
+ */
+function isClassDeclaration(node, classDeclarationRegex) {
+  let name;
+  switch (node.type) {
+    case 'VariableDeclarator':
+      name = node.id.name;
+      break;
+    default:
+      name = '';
+  }
+  if (!name) {
+    return false;
+  }
+  return new RegExp(classDeclarationRegex).test(name);
+}
+
+/**
  * Find out if node is `class`
  *
  * @param {ASTNode} node The AST node being checked
@@ -65,6 +87,53 @@ function isVueClassAttribute(node, classRegex) {
       re.test(node.key.argument.name):
       // v-bind:class="vue-classes-as-bind"
       // :class="vue-classes-as-bind"
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Find out if a node is just simple text
+ *
+ * @param {ASTNode} node The AST node being checked
+ * @returns {Boolean}
+ */
+function isLiteralValue(node) {
+  return node && node.type === 'Literal';
+}
+
+/**
+ * Find out if a node is an ArrayExpression
+ *
+ * @param {ASTNode} node The AST node being checked
+ * @returns {Boolean}
+ */
+function isArrayExpression(node) {
+  return node && node.type === 'ArrayExpression';
+}
+
+/**
+ * Find out if a node is an ObjectExpression
+ *
+ * @param {ASTNode} node The AST node being checked
+ * @returns {Boolean}
+ */
+function isObjectExpression(node) {
+  return node && node.type === 'ObjectExpression';
+}
+
+/**
+ * Find out if node's init attribute is just simple text
+ *
+ * @param {ASTNode} node The AST node being checked
+ * @returns {Boolean}
+ */
+function isValidDeclaratorValue(node) {
+  switch (true) {
+    case isLiteralValue(node.init): // Simple string
+    case isArrayExpression(node.init): // ['tw-unknown-class']
+    case isObjectExpression(node.init): // {'tw-unknown-class': true}
       return true;
     default:
       return false;
@@ -360,7 +429,12 @@ module.exports = {
   extractValueFromNode,
   extractClassnamesFromValue,
   isClassAttribute,
+  isClassDeclaration,
+  isLiteralValue,
+  isArrayExpression,
+  isObjectExpression,
   isLiteralAttributeValue,
+  isValidDeclaratorValue,
   isVArrayExpression,
   isVObjectExpression,
   isValidJSXAttribute,

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -124,6 +124,16 @@ function isObjectExpression(node) {
 }
 
 /**
+ * Find out if a node is an ConditionalExpression
+ *
+ * @param {ASTNode} node The AST node being checked
+ * @returns {Boolean}
+ */
+function isConditionalExpression(node) {
+  return node && node.type === 'ConditionalExpression';
+}
+
+/**
  * Find out if node's value attribute is just simple text
  *
  * @param {ASTNode} node The AST node being checked
@@ -134,6 +144,7 @@ function isValidDeclaratorValue(node) {
     case isLiteralValue(node.init): // Simple string
     case isArrayExpression(node.init): // ['tw-unknown-class']
     case isObjectExpression(node.init): // {'tw-unknown-class': true}
+    case isConditionalExpression(node.init): // bool ? 'tw-unknown-class' : 'tw-unknown-class'
       return true;
     default:
       return false;
@@ -432,6 +443,7 @@ module.exports = {
   isLiteralValue,
   isArrayExpression,
   isObjectExpression,
+  isConditionalExpression,
   isLiteralAttributeValue,
   isValidDeclaratorValue,
   isVArrayExpression,

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -313,7 +313,7 @@ function extractClassnamesFromValue(classStr) {
  * @param {Array} ignoredKeys Optional, set object keys which should not be parsed e.g. for `cva`
  * @returns {void}
  */
-function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, isolate = false, ignoredKeys = [], callee = false) {
+function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, isolate = false, ignoredKeys = [], calleeKey = false) {
   // TODO allow vue non litteral
   let originalClassNamesValue;
   let classNames;
@@ -335,22 +335,22 @@ function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, is
     switch (childNode.type) {
       case 'TemplateLiteral':
         childNode.expressions.forEach((exp) => {
-          parseNodeRecursive(rootNode, exp, cb, skipConditional, forceIsolation, ignoredKeys, callee);
+          parseNodeRecursive(rootNode, exp, cb, skipConditional, forceIsolation, ignoredKeys, calleeKey);
         });
         childNode.quasis.forEach((quasis) => {
-          parseNodeRecursive(rootNode, quasis, cb, skipConditional, isolate, ignoredKeys, callee);
+          parseNodeRecursive(rootNode, quasis, cb, skipConditional, isolate, ignoredKeys, calleeKey);
         });
         return;
       case 'ConditionalExpression':
-        parseNodeRecursive(rootNode, childNode.consequent, cb, skipConditional, forceIsolation, ignoredKeys, callee);
-        parseNodeRecursive(rootNode, childNode.alternate, cb, skipConditional, forceIsolation, ignoredKeys, callee);
+        parseNodeRecursive(rootNode, childNode.consequent, cb, skipConditional, forceIsolation, ignoredKeys, calleeKey);
+        parseNodeRecursive(rootNode, childNode.alternate, cb, skipConditional, forceIsolation, ignoredKeys, calleeKey);
         return;
       case 'LogicalExpression':
-        parseNodeRecursive(rootNode, childNode.right, cb, skipConditional, forceIsolation, ignoredKeys, callee);
+        parseNodeRecursive(rootNode, childNode.right, cb, skipConditional, forceIsolation, ignoredKeys, calleeKey);
         return;
       case 'ArrayExpression':
         childNode.elements.forEach((el) => {
-          parseNodeRecursive(rootNode, el, cb, skipConditional, forceIsolation, ignoredKeys, callee);
+          parseNodeRecursive(rootNode, el, cb, skipConditional, forceIsolation, ignoredKeys, calleeKey);
         });
         return;
       case 'ObjectExpression':
@@ -367,17 +367,17 @@ function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, is
 
           parseNodeRecursive(
             rootNode,
-            callee ? prop.key : prop.value,
+            calleeKey ? prop.key : prop.value,
             cb,
             skipConditional,
             forceIsolation,
             ignoredKeys,
-            callee
+            calleeKey
           );
         });
         return;
       case 'Property':
-        parseNodeRecursive(rootNode, childNode.key, cb, skipConditional, forceIsolation, ignoredKeys, callee);
+        parseNodeRecursive(rootNode, childNode.key, cb, skipConditional, forceIsolation, ignoredKeys, calleeKey);
         return;
       case 'Literal':
         trim = true;

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -367,7 +367,7 @@ function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, is
 
           parseNodeRecursive(
             rootNode,
-            isUsedByClassNamesPlugin ? prop.key : prop.value,
+            callee ? prop.key : prop.value,
             cb,
             skipConditional,
             forceIsolation,

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -313,7 +313,7 @@ function extractClassnamesFromValue(classStr) {
  * @param {Array} ignoredKeys Optional, set object keys which should not be parsed e.g. for `cva`
  * @returns {void}
  */
-function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, isolate = false, ignoredKeys = []) {
+function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, isolate = false, ignoredKeys = [], callee = false) {
   // TODO allow vue non litteral
   let originalClassNamesValue;
   let classNames;
@@ -335,28 +335,26 @@ function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, is
     switch (childNode.type) {
       case 'TemplateLiteral':
         childNode.expressions.forEach((exp) => {
-          parseNodeRecursive(rootNode, exp, cb, skipConditional, forceIsolation, ignoredKeys);
+          parseNodeRecursive(rootNode, exp, cb, skipConditional, forceIsolation, ignoredKeys, callee);
         });
         childNode.quasis.forEach((quasis) => {
-          parseNodeRecursive(rootNode, quasis, cb, skipConditional, isolate, ignoredKeys);
+          parseNodeRecursive(rootNode, quasis, cb, skipConditional, isolate, ignoredKeys, callee);
         });
         return;
       case 'ConditionalExpression':
-        parseNodeRecursive(rootNode, childNode.consequent, cb, skipConditional, forceIsolation, ignoredKeys);
-        parseNodeRecursive(rootNode, childNode.alternate, cb, skipConditional, forceIsolation, ignoredKeys);
+        parseNodeRecursive(rootNode, childNode.consequent, cb, skipConditional, forceIsolation, ignoredKeys, callee);
+        parseNodeRecursive(rootNode, childNode.alternate, cb, skipConditional, forceIsolation, ignoredKeys, callee);
         return;
       case 'LogicalExpression':
-        parseNodeRecursive(rootNode, childNode.right, cb, skipConditional, forceIsolation, ignoredKeys);
+        parseNodeRecursive(rootNode, childNode.right, cb, skipConditional, forceIsolation, ignoredKeys, callee);
         return;
       case 'ArrayExpression':
         childNode.elements.forEach((el) => {
-          parseNodeRecursive(rootNode, el, cb, skipConditional, forceIsolation, ignoredKeys);
+          parseNodeRecursive(rootNode, el, cb, skipConditional, forceIsolation, ignoredKeys, callee);
         });
         return;
       case 'ObjectExpression':
         childNode.properties.forEach((prop) => {
-          const isUsedByClassNamesPlugin = rootNode.callee && rootNode.callee.name === 'classnames';
-
           if (prop.type === 'SpreadElement') {
             // Ignore spread elements
             return;
@@ -373,12 +371,13 @@ function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, is
             cb,
             skipConditional,
             forceIsolation,
-            ignoredKeys
+            ignoredKeys,
+            callee
           );
         });
         return;
       case 'Property':
-        parseNodeRecursive(rootNode, childNode.key, cb, skipConditional, forceIsolation, ignoredKeys);
+        parseNodeRecursive(rootNode, childNode.key, cb, skipConditional, forceIsolation, ignoredKeys, callee);
         return;
       case 'Literal':
         trim = true;

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -87,7 +87,7 @@ function isVLiteralValue(node) {
  * @param {ASTNode} node The AST node being checked
  * @returns {Boolean}
  */
-function isArrayExpression(node) {
+function isVArrayExpression(node) {
   return node.value && node.value.type === 'VExpressionContainer' && node.value.expression.type === 'ArrayExpression';
 }
 
@@ -97,7 +97,7 @@ function isArrayExpression(node) {
  * @param {ASTNode} node The AST node being checked
  * @returns {Boolean}
  */
-function isObjectExpression(node) {
+function isVObjectExpression(node) {
   return node.value && node.value.type === 'VExpressionContainer' && node.value.expression.type === 'ObjectExpression';
 }
 
@@ -110,10 +110,9 @@ function isObjectExpression(node) {
 function isVueValidAttributeValue(node) {
   switch (true) {
     case isVLiteralValue(node): // Simple string
-    case isArrayExpression(node): // ['tw-unknown-class']
-    case isObjectExpression(node): // {'tw-unknown-class': true}
+    case isVArrayExpression(node): // ['tw-unknown-class']
+    case isVObjectExpression(node): // {'tw-unknown-class': true}
       return true;
-      break;
     default:
       return false;
   }
@@ -362,8 +361,8 @@ module.exports = {
   extractClassnamesFromValue,
   isClassAttribute,
   isLiteralAttributeValue,
-  isArrayExpression,
-  isObjectExpression,
+  isVArrayExpression,
+  isVObjectExpression,
   isValidJSXAttribute,
   isValidVueAttribute,
   isVLiteralValue,

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -43,13 +43,13 @@ function isClassAttribute(node, classRegex) {
 }
 
 /**
- * Find out if node is a class variable declaration
+ * Find out if node is a variable declaration
  *
  * @param {ASTNode} node The AST node being checked
  * @param {String} classDeclarationRegex Regex to test the attribute that is being checked against
  * @returns {Boolean}
  */
-function isClassDeclaration(node, classDeclarationRegex) {
+function isVariableDeclaration(node, classDeclarationRegex) {
   let name;
   switch (node.type) {
     case 'VariableDeclarator':
@@ -124,7 +124,7 @@ function isObjectExpression(node) {
 }
 
 /**
- * Find out if node's init attribute is just simple text
+ * Find out if node's value attribute is just simple text
  *
  * @param {ASTNode} node The AST node being checked
  * @returns {Boolean}
@@ -429,7 +429,7 @@ module.exports = {
   extractValueFromNode,
   extractClassnamesFromValue,
   isClassAttribute,
-  isClassDeclaration,
+  isVariableDeclaration,
   isLiteralValue,
   isArrayExpression,
   isObjectExpression,

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -14,7 +14,7 @@ function getOption(context, name) {
   // Fallback to defaults
   switch (name) {
     case 'callees':
-      return ['classnames', 'clsx', 'ctl', 'cva', 'tv'];
+      return { classnames: 'key', clsx: 'key', ctl: 'value', cva: 'value', tv: 'value' };
     case 'ignoredKeys':
       return ['compoundVariants', 'defaultVariants'];
     case 'classRegex':
@@ -40,4 +40,27 @@ function getOption(context, name) {
   }
 }
 
-module.exports = getOption;
+function normalizeCallees(callees) {
+  const defaultCallees = getOption({ options: [{}] }, 'callees');
+  if (Array.isArray(callees)) {
+    return callees.reduce((acc, callee) => {
+      if (typeof callee === 'string') {
+        acc[callee] = defaultCallees[callee] ?? 'value';
+      } else {
+        throw new Error(`Invalid callee: ${callee}`);
+      }
+      return acc;
+    }, {});
+  }
+  Object.keys(callees).forEach((callee) => {
+    if (callees[callee] !== 'key' && callees[callee] !== 'value') {
+      throw new Error(`Invalid callee: ${callee}`);
+    }
+  });
+  return callees;
+}
+
+module.exports = {
+  getOption,
+  normalizeCallees
+};

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -33,6 +33,10 @@ function getOption(context, name) {
       return [];
     case 'whitelist':
       return [];
+    case 'declarationRegex':
+      return '^(classes|classNames?|.*Styles)$';
+    case 'skipClassDeclaration':
+      return false;
   }
 }
 


### PR DESCRIPTION
# Parse Variable Declarations

## Description
This PR fixes a hole in the current evaluation.

Currently, the following code misses the incorrect class name:
```jsx
const myStyles = 'bg-wrong-name';

const classNames = [
  {
    base: 'text-wrong-text',
    other: 'flex-no-layout'
  }
];

export function Item() {
  return <div className={clsx('bg-current')} />;
}
```

This update will identify the wrong class names in all variable declarations with string, object, or array values.
(It will also identify duplicate class names)