### PR TITLE
fix: Mark tailwindcss as optional peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,11 @@
       },
       "peerDependencies": {
         "tailwindcss": "^3.3.2"
+      },
+      "peerDependenciesMeta": {
+        "tailwindcss": {
+          "optional": true
+        }
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
   "peerDependencies": {
     "tailwindcss": "^3.3.2"
   },
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "fast-glob": "^3.2.5",
     "postcss": "^8.4.4"


### PR DESCRIPTION
# Mark tailwindcss as optional peer dependency

## Description

When this plugin is included in a shareable config, the usage of Tailwind might be optional (see e.g. https://github.com/molindo/eslint-config-molindo).

Other popular ESLint plugin mark closely related peer dependencies as optional too for this reason (see e.g. [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest/pull/970)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I know the strategy to be working from other ESLint plugins.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
