### PR TITLE
fix: Parsing spreads in function call returns

### DIFF
--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -211,10 +211,9 @@ function extractValueFromNode(node) {
         case 'ArrayExpression':
           return node.value.expression.elements;
           break;
-        case 'ObjectExpression': {
+        case 'ObjectExpression':
           return node.value.expression.properties;
           break;
-        }
       }
       return node.value.expression.value;
     default:

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -184,6 +184,9 @@ function extractRangeFromNode(node) {
   if (node.type === 'TextAttribute' && node.name === 'class') {
     return [node.valueSpan.fullStart.offset, node.valueSpan.end.offset];
   }
+  if (node.value === undefined) {
+    return [0,0];
+  }
   switch (node.value.type) {
     case 'JSXExpressionContainer':
       return node.value.expression.range;
@@ -196,6 +199,10 @@ function extractValueFromNode(node) {
   if (node.type === 'TextAttribute' && node.name === 'class') {
     return node.value;
   }
+  if (node.value === undefined) {
+    return node.value;
+  }
+
   switch (node.value.type) {
     case 'JSXExpressionContainer':
       return node.value.expression.value;
@@ -204,9 +211,10 @@ function extractValueFromNode(node) {
         case 'ArrayExpression':
           return node.value.expression.elements;
           break;
-        case 'ObjectExpression':
+        case 'ObjectExpression': {
           return node.value.expression.properties;
           break;
+        }
       }
       return node.value.expression.value;
     default:

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -281,6 +281,14 @@ ruleTester.run("classnames-order", rule, {
     {
       code: `<div class="py-1\u3000px-2 block">Do not treat full width space as class separator</div>`,
     },
+    {
+      code: `
+        const func = () => ({ a: 12 });
+        <div className={clsx(['text-sm', {
+          ...func()
+        }])}>Spread of a function return inside clsx</div>
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
# Function return spreading

## Description

Similarly to https://github.com/francoismassart/eslint-plugin-tailwindcss/pull/251 spreading function return values inside of `clsx` call or similar fails with `TypeError: Cannot read properties of undefined (reading 'type')`

This is a simple fix to simply ignore those nodes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I added a test that matches my minimal reproduction. It fails without the introduced change.

**Test Configuration**:
* OS + version: e.g. macOS Mojave
* NPM version: ...
* Node version: ...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
