### PR TITLE
Update wording of class order message

### DIFF
--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -19,7 +19,7 @@ const createContextFallback = require('tailwindcss/lib/lib/setupContextUtils').c
 
 // Predefine message for use in context.report conditional.
 // messageId will still be usable in tests.
-const INVALID_CLASSNAMES_ORDER_MSG = 'Invalid Tailwind CSS classnames order';
+const INVALID_CLASSNAMES_ORDER_MSG = 'Incorrect Tailwind CSS class order';
 
 const contextFallbackCache = new WeakMap();
 


### PR DESCRIPTION
## Description

This is a small nitpick — it changes the wording of the message when linting for class order.
- Changes from `invalid` to `incorrect`. The class order may be wrong but it's still valid CSS / Tailwind.
- Changes from `classnames order` to `class order` since the things being ordered are classes.

## Type of change

(none of the listed options — just updates a single string)

## How Has This Been Tested?

Nothing too extensive. I ran the test suite locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
