### PR TITLE
Fixed regression if lint runs more than cssFilesRefreshRate

### DIFF
--- a/lib/util/cssFiles.js
+++ b/lib/util/cssFiles.js
@@ -1,13 +1,36 @@
+// @ts-check
 'use strict';
 
 const fg = require('fast-glob');
 const fs = require('fs');
 const postcss = require('postcss');
-const removeDuplicatesFromArray = require('./removeDuplicatesFromArray');
 
-let previousGlobsResults = [];
+const classRegexp = /\.([^\.\,\s\n\:\(\)\[\]\'~\+\>\*\\]*)/gim;
+
 let lastUpdate = null;
 let classnamesFromFiles = [];
+
+/**
+ * @type {Map<string, {
+ *  timestamp: number;
+ *  classes: ReadonlySet<string>
+ * }>}
+ */
+const prevFileCache = new Map();
+
+const SetHelper = {
+  /**
+   *
+   * @template T
+   * @param {Set<T>} set
+   * @param {Iterable<T>} items
+   */
+  addMany: (set, items) => {
+    for (const item of items) {
+      set.add(item);
+    }
+  },
+};
 
 /**
  * Read CSS files and extract classnames
@@ -17,26 +40,74 @@ let classnamesFromFiles = [];
  */
 const generateClassnamesListSync = (patterns, refreshRate = 5_000) => {
   const now = new Date().getTime();
-  const files = fg.sync(patterns, { suppressErrors: true });
-  const newGlobs = previousGlobsResults.flat().join(',') != files.flat().join(',');
   const expired = lastUpdate === null || now - lastUpdate > refreshRate;
-  if (newGlobs || expired) {
-    previousGlobsResults = files;
-    lastUpdate = now;
-    let detectedClassnames = [];
-    for (const file of files) {
+
+  if (!expired) {
+    return classnamesFromFiles;
+  }
+  const files = fg.sync(patterns, { suppressErrors: true, stats: true });
+  lastUpdate = now;
+
+  /**
+   * @type {Set<string>}
+   */
+  const detectedClassnames = new Set();
+  /**
+   * @type {Set<string>}
+   */
+  const filesSet = new Set();
+  for (const { path: file, stats } of files) {
+    const prevData = prevFileCache.get(file);
+    const timestamp = stats?.mtimeMs;
+    /**
+     * @type {ReadonlySet<string>}
+     */
+    let classes;
+    // file is not changed -> we do need to do extra work
+    if (prevData && prevData?.timestamp === timestamp) {
+      classes = prevData.classes;
+    } else {
+      /**
+       * @type {Set<string>}
+       */
+      const curClasses = new Set();
       const data = fs.readFileSync(file, 'utf-8');
       const root = postcss.parse(data);
       root.walkRules((rule) => {
-        const regexp = /\.([^\.\,\s\n\:\(\)\[\]\'~\+\>\*\\]*)/gim;
-        const matches = [...rule.selector.matchAll(regexp)];
-        const classnames = matches.map((arr) => arr[1]);
-        detectedClassnames.push(...classnames);
+        for (const match of rule.selector.matchAll(classRegexp)) {
+          curClasses.add(match[1]);
+        }
       });
-      detectedClassnames = removeDuplicatesFromArray(detectedClassnames);
+
+      classes = curClasses;
+
+      if (timestamp) {
+        prevFileCache.set(file, {
+          classes,
+          timestamp,
+        });
+      }
     }
-    classnamesFromFiles = detectedClassnames;
+
+    SetHelper.addMany(detectedClassnames, classes);
+    filesSet.add(file);
   }
+  // avoiding memory leak
+  {
+    /**
+     * @type {string[]}
+     */
+    const keysToDelete = [];
+    for (const cachedFilePath of prevFileCache.keys()) {
+      if (!filesSet.has(cachedFilePath)) {
+        keysToDelete.push(cachedFilePath);
+      }
+    }
+    for (const key of keysToDelete) {
+      prevFileCache.delete(key);
+    }
+  }
+  classnamesFromFiles = [...detectedClassnames];
   return classnamesFromFiles;
 };
 


### PR DESCRIPTION
# Pull Request Name

## Description

Tries to fix behavior regression

Fixes https://github.com/francoismassart/eslint-plugin-tailwindcss/pull/338#discussion_r1628453766

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- [x] Runed tests
- [ ] Add E2E test that checks lint running more than cssRefreshTime

**Test Configuration**:

- OS + version: e.g. macOS Mojave
- NPM version: ...
- Node version: ...

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
