### PR TITLE
fix ast expression tests for null expressions

### DIFF
--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -96,7 +96,7 @@ function isVLiteralValue(node) {
  * @returns {Boolean}
  */
 function isArrayExpression(node) {
-  return node.value && node.value.type === 'VExpressionContainer' && node.value.expression.type === 'ArrayExpression';
+  return node.value && node.value.type === 'VExpressionContainer' && node.value.expression && node.value.expression.type === 'ArrayExpression';
 }
 
 /**
@@ -106,7 +106,7 @@ function isArrayExpression(node) {
  * @returns {Boolean}
  */
 function isObjectExpression(node) {
-  return node.value && node.value.type === 'VExpressionContainer' && node.value.expression.type === 'ObjectExpression';
+  return node.value && node.value.type === 'VExpressionContainer' && node.value.expression && node.value.expression.type === 'ObjectExpression';
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "vue-eslint-parser": "^9.4.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.12.0"
       },
       "peerDependencies": {
         "tailwindcss": "^3.4.0"

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -444,7 +444,7 @@ ruleTester.run("no-custom-classname", rule, {
         },
       ],
     },
-    ...(['myTag', 'myTag.subTag', 'myTag(SomeComponent)'].map(tag => ({
+    ...["myTag", "myTag.subTag", "myTag(SomeComponent)"].map((tag) => ({
       code: `
       ${tag}\`
         sm:w-6
@@ -455,7 +455,7 @@ ruleTester.run("no-custom-classname", rule, {
         lg:w-4
       \`;`,
       options: [{ tags: ["myTag"] }],
-    }))),
+    })),
     {
       code: `
       <div class="flex flex-row-reverse space-x-4 space-x-reverse">
@@ -1063,6 +1063,32 @@ ruleTester.run("no-custom-classname", rule, {
       code: `
       <h1 class="forced-color-adjust-none">New forced-color-adjust utilities</h1>`,
     },
+    {
+      // fix ast expression tests for null expressions
+      // @see https://github.com/francoismassart/eslint-plugin-tailwindcss/pull/345
+      code: `
+      <template>
+        <div
+          class="text-end"
+          :class="(marketValue ?? 0) < (totalCost ?? 0) ? 'text-danger' : 'text-success'"
+        >
+          {{ marketValue?.toFixed(2) }}
+        </div>
+      </template>
+
+      <script>
+      export default {
+        data () {
+          return {
+            marketValue: 10,
+            totalCost: 10
+          };
+        }
+      };
+      </script>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+    },
   ],
 
   invalid: [
@@ -1224,7 +1250,7 @@ ruleTester.run("no-custom-classname", rule, {
       ],
       errors: generateErrors("dark"),
     },
-    ...(['myTag', 'myTag.subTag', 'myTag(SomeComponent)'].flatMap(tag => ([
+    ...["myTag", "myTag.subTag", "myTag(SomeComponent)"].flatMap((tag) => [
       {
         code: `
         ${tag}\`
@@ -1272,7 +1298,7 @@ ruleTester.run("no-custom-classname", rule, {
         options: [{ tags: ["myTag"] }],
         errors: generateErrors("custom-2 custom-1"),
       },
-    ]))),
+    ]),
     {
       code: `
       <div class="bg-red-600 p-10">


### PR DESCRIPTION
# Pull Request Name
Fix a TypeError exception for null expressions in the AST.

## Description

While linting my application, exceptions about the AST are raised in some components:

```
TypeError: Cannot read properties of null (reading 'type') Occurred while linting /app/src/components/TestComponent.vue:47 Rule: "vue/attributes-order"
    at isArrayExpression (/app/node_modules/eslint-plugin-tailwindcss/lib/util/ast.js:99:92)
    at isVueValidAttributeValue (/app/node_modules/eslint-plugin-tailwindcss/lib/util/ast.js:121:10)
    at Object.isValidVueAttribute (/app/node_modules/eslint-plugin-tailwindcss/lib/util/ast.js:184:8)

```

Apparently the `VExpressionContainer` can pass all the checks, but the value for `expression` is `null`. This modification makes sure it is not treated as an object that can be passed onward.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Linting fails on some components in our big application, this change fixes the thrown exception.

**Test Configuration**:

- OS + version: Debian 11
- NPM version: 10.8.1
- Node version: 22.3.0