### PR TITLE
Resolve new configs in shallow-cloned monorepo on CI

### DIFF
--- a/lib/util/customConfig.js
+++ b/lib/util/customConfig.js
@@ -36,9 +36,11 @@ function requireUncached(module) {
 /**
  * Load the config from a path string or parsed from an object
  * @param {string|Object} config
+ * @param {object} options
+ * @param {boolean} options.newConfig when the config has a different path we must resolve even if mtime is the same
  * @returns `null` when unchanged, `{}` when not found
  */
-function loadConfig(config) {
+function loadConfig(config, options) {
   let loadedConfig = null;
   if (typeof config === 'string') {
     const resolvedPath = path.isAbsolute(config) ? config : path.join(path.resolve(), config);
@@ -48,7 +50,7 @@ function loadConfig(config) {
       if (stats === null) {
         // Default to no config
         loadedConfig = {};
-      } else if (lastModifiedDate !== mtime) {
+      } else if (options.newConfig || lastModifiedDate !== mtime) {
         // Load the config based on path
         lastModifiedDate = mtime;
         loadedConfig = requireUncached(resolvedPath);
@@ -88,7 +90,7 @@ function resolve(twConfig) {
   if (newConfig || expired) {
     previousConfig = twConfig;
     lastCheck = now;
-    const userConfig = loadConfig(twConfig);
+    const userConfig = loadConfig(twConfig, { newConfig });
     // userConfig is null when config file was not modified
     if (userConfig !== null) {
       mergedConfig = resolveConfig(userConfig);


### PR DESCRIPTION
# Pull Request Name

Resolve new configs in shallow-cloned monorepo on CI

## Description

If the config path changed, we now resolve even if the new and old configs were modified at the same time. This helps with monorepos in shallow clones on Continuous Integration environments.

I plumbed the `newConfig` flag down to `loadConfig` function, as we've already modified the previous path.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I lazily ran this on CI in a PR I'm working on: https://github.com/kamilkisiela/graphql-hive/pull/5466

Would probably need a proper e2e/integration test.

**Test Configuration**:

- OS + version: macOS Sonoma 14.6.1
- NPM version: 10.8.2
- Node version: 22.5.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
