### PR TITLE
Fix custom classnames rule with VueJS objects within list.

### DIFF
--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -121,7 +121,6 @@ function isVueValidAttributeValue(node) {
     case isArrayExpression(node): // ['tw-unknown-class']
     case isObjectExpression(node): // {'tw-unknown-class': true}
       return true;
-      break;
     default:
       return false;
   }
@@ -218,10 +217,8 @@ function extractValueFromNode(node) {
       switch (node.value.expression.type) {
         case 'ArrayExpression':
           return node.value.expression.elements;
-          break;
         case 'ObjectExpression':
           return node.value.expression.properties;
-          break;
       }
       return node.value.expression.value;
     default:
@@ -302,7 +299,7 @@ function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, is
         return;
       case 'ObjectExpression':
         childNode.properties.forEach((prop) => {
-          const isUsedByClassNamesPlugin = rootNode.callee && rootNode.callee.name === 'classnames';
+          const isUsedByClassNamesPlugin = (rootNode.callee && rootNode.callee.name === 'classnames') || rootNode.type === 'VAttribute';
 
           if (prop.type === 'SpreadElement') {
             // Ignore spread elements

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "scripts": {
     "test": "npm run test:base && npm run test:integration",
     "test:base": "mocha \"tests/lib/**/*.js\"",
-    "test:no-custom-classname": "mocha \"tests/lib/rules/no-custom-classname.js\"",
     "test:integration": "mocha \"tests/integrations/*.js\" --timeout 60000"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "test": "npm run test:base && npm run test:integration",
     "test:base": "mocha \"tests/lib/**/*.js\"",
+    "test:no-custom-classname": "mocha \"tests/lib/rules/no-custom-classname.js\"",
     "test:integration": "mocha \"tests/integrations/*.js\" --timeout 60000"
   },
   "files": [

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -1089,6 +1089,36 @@ ruleTester.run("no-custom-classname", rule, {
       filename: "test.vue",
       parser: require.resolve("vue-eslint-parser"),
     },
+    {
+      code: `<template><div :class="[{'text-red-500': true, 'bg-transparent': false}]">Issue #319</div></template>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+    },
+    {
+      code: `<template><div :class="['hidden',{'text-red-500': true, 'bg-transparent': false}, 'text-red-200']">Issue #319</div></template>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+    },
+    {
+      code: `<template><div :class="['tw-hidden',{'tw-text-red-500': true, 'tw-bg-transparent': false}, 'tw-text-red-200']">Issue #319</div></template>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+      options: [
+        {
+          config: {
+            prefix: "tw-",
+            theme: {
+              extend: {},
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: `<template><div :class="['hidden',{'text-red-500': true, 'bg-transparent': false}, {'text-green-500': true}, 'bg-white']">Issue #319</div></template>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+    }
   ],
 
   invalid: [
@@ -1434,6 +1464,59 @@ ruleTester.run("no-custom-classname", rule, {
       ),
       filename: "test.vue",
       parser: require.resolve("vue-eslint-parser"),
+    },
+    {
+      code: `
+      <script>
+      export default {
+        data() {
+          return {}
+        }
+      }
+      </script>
+      <template>
+        <span :class="['text-red-200', {'tw-unknown-class': true, 'tw-unknown-class-two': false}, 'tw-unknown-class-three', 'tw-bg-transparent']" /> 
+      </template>
+      `,
+      options: [
+        {
+          config: {
+            prefix: "tw-",
+            theme: {
+              extend: {},
+            },
+          },
+        },
+      ],
+      errors: generateErrors(
+        "text-red-200 tw-unknown-class tw-unknown-class-two tw-unknown-class-three"
+      ),
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+    },
+    {
+      code: `<template><div :class="[{'baz': true, 'foo': false}]">Issue #319</div></template>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+      errors: generateErrors("baz foo"),
+    },
+    {
+      code: `<template><div :class="['unknown',{'baz': true, 'foo': false}]">Issue #319</div></template>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+      errors: generateErrors("unknown baz foo"),
+    },
+    {
+      code: `<template><div :class="['text-red-200','unknown',{'baz': true, 'foo': false}, 'tw-unknown-class']">Issue #319</div></template>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+      errors: generateErrors("unknown baz foo tw-unknown-class"),
+    },
+    {
+      code: `<template><div :class="['tw-hidden',{'custom': true, '🧑‍💻': false}, {'text-green-500': true}, 'bg-tw']">Issue #319</div></template>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+      errors: generateErrors("tw-hidden custom 🧑‍💻 bg-tw"),
     },
     {
       code: `<div className="group-hover/edit:unknown-class">Custom group name variant with invalid class name</div>`,

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -1100,6 +1100,11 @@ ruleTester.run("no-custom-classname", rule, {
       parser: require.resolve("vue-eslint-parser"),
     },
     {
+      code: `<template><div :class="[{'text-red-500': true}, 'bg-white']" :prop="['baz', true, 'foo']" :other="['val', {'baz': true, 'text-green-400': false}]">Issue #319</div></template>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+    },
+    {
       code: `<template><div :class="['tw-hidden',{'tw-text-red-500': true, 'tw-bg-transparent': false}, 'tw-text-red-200']">Issue #319</div></template>`,
       filename: "test.vue",
       parser: require.resolve("vue-eslint-parser"),
@@ -1517,6 +1522,12 @@ ruleTester.run("no-custom-classname", rule, {
       filename: "test.vue",
       parser: require.resolve("vue-eslint-parser"),
       errors: generateErrors("tw-hidden custom 🧑‍💻 bg-tw"),
+    },
+    {
+      code: `<template><div :class="[{'baz': true, 'foo': false}]" :prop="['baz', true, 'foo']" :other="['val', {'baz': true, 'foo': false}]">Issue #319</div></template>`,
+      filename: "test.vue",
+      parser: require.resolve("vue-eslint-parser"),
+      errors: generateErrors("baz foo"),
     },
     {
       code: `<div className="group-hover/edit:unknown-class">Custom group name variant with invalid class name</div>`,


### PR DESCRIPTION
# Fix custom classnames rule with VueJS objects within list syntax.

## Description

This PR fixes an issue occurring with the `no-custom-classname` rule, where it did not detect custom classes inside *object in list* patterns:
`<div :class="[{'custom-not-detected': true}]"/>`.

Fixes #319 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change => existing will work, but more warnings will be issued

## How Has This Been Tested?

New tests have been added. They're all using vue-eslint-parser in a .vue file.

- Testing for invalid/valid classes when using object within list
- Testing with a mix of valid/invalid within the object, and with classes written directly in the array.
- Testing with multiple objects and classes between them, in an array.

**Test Configuration**:

- OS + version: macOS Sequoia 15.0 (24A335)
- NPM version: 10.8.3
- Node version: 22.6.0

## Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas => should probably comment in ast as it's an important part of the plugin?
- [ ] I have made corresponding changes to the documentation => no need as it's a fix
- [ ] My changes generate no new warnings => it probably will as it can detect new classes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

---
- VSCode with TS automatically removed some unreachable code.
- I added a check in the ast util, it's working well as all tests passed, but I don't know if it is the cleanest way to do that.
