### PR TITLE
fix: Make `tailwindcss` peer dependency optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "peerDependencies": {
     "tailwindcss": "^3.4.0"
   },
-	"peerDependenciesMeta": {
-		"tailwindcss": {
-			"optional": true
-		}
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
 	},
   "dependencies": {
     "fast-glob": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
   "peerDependencies": {
     "tailwindcss": "^3.4.0"
   },
+	"peerDependenciesMeta": {
+		"tailwindcss": {
+			"optional": true
+		}
+	},
   "dependencies": {
     "fast-glob": "^3.2.5",
     "postcss": "^8.4.4"


### PR DESCRIPTION
# fix: Make `tailwindcss` peer dependency optional

## Description

This makes this plugin easier to consume when it's installed as part of a shared config, in case `tailwindcss` is not installed by the host.

See also: https://github.com/jest-community/eslint-plugin-jest/pull/970
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Known to work from [other plugins](https://github.com/jest-community/eslint-plugin-jest/pull/970).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
