### PR TITLE
fix: customConfig.resolve two files with the same modification time

### DIFF
--- a/lib/util/customConfig.js
+++ b/lib/util/customConfig.js
@@ -36,22 +36,22 @@ function requireUncached(module) {
 /**
  * Load the config from a path string or parsed from an object
  * @param {string|Object} config
+ * @param {boolean} newConfig
  * @returns `null` when unchanged, `{}` when not found
  */
-function loadConfig(config) {
+function loadConfig(config, newConfig) {
   let loadedConfig = null;
   if (typeof config === 'string') {
-    const resolvedPath = path.isAbsolute(config) ? config : path.join(path.resolve(), config);
     try {
-      const stats = fs.statSync(resolvedPath);
+      const stats = fs.statSync(config);
       const mtime = `${stats.mtime || ''}`;
       if (stats === null) {
         // Default to no config
         loadedConfig = {};
-      } else if (lastModifiedDate !== mtime) {
+      } else if (newConfig || lastModifiedDate !== mtime) {
         // Load the config based on path
         lastModifiedDate = mtime;
-        loadedConfig = requireUncached(resolvedPath);
+        loadedConfig = requireUncached(config);
       } else {
         // Unchanged config
         loadedConfig = null;
@@ -81,14 +81,24 @@ function convertConfigToString(config) {
   }
 }
 
+function getResolvedConfig(config) {
+  switch (typeof config) {
+    case 'string':
+      return path.isAbsolute(config) ? config : path.join(path.resolve(), config);
+    default:
+      return config;
+  }
+}
+
 function resolve(twConfig) {
-  const newConfig = convertConfigToString(twConfig) !== convertConfigToString(previousConfig);
+  const resolvedConfig = getResolvedConfig(twConfig);
+  const newConfig = convertConfigToString(resolvedConfig) !== convertConfigToString(previousConfig);
   const now = Date.now();
   const expired = now - lastCheck > CHECK_REFRESH_RATE;
   if (newConfig || expired) {
-    previousConfig = twConfig;
+    previousConfig = resolvedConfig;
     lastCheck = now;
-    const userConfig = loadConfig(twConfig);
+    const userConfig = loadConfig(resolvedConfig, newConfig);
     // userConfig is null when config file was not modified
     if (userConfig !== null) {
       mergedConfig = resolveConfig(userConfig);

--- a/tests/lib/util/customConfig.js
+++ b/tests/lib/util/customConfig.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Test customConfig utilities
+ * @author David Hart
+ */
+"use strict";
+
+var assert = require("assert");
+var fs = require("fs");
+var path = require("path");
+var resolveConfig = require("tailwindcss/resolveConfig");
+var customConfig = require("../../../lib/util/customConfig");
+
+describe("resolve", function () {
+  it("should work with an object", function () {
+    const result = customConfig.resolve({ a: 1, b: 2 });
+    assert.deepEqual(result, resolveConfig({ a: 1, b: 2 }));
+  });
+
+  describe("with two config files at different paths with the same modification time", function () {
+    before(() => {
+      fs.writeFileSync("config1.js", "module.exports = { a: 1 }");
+      fs.writeFileSync("config2.js", "module.exports = { a: 2 }");
+    });
+
+    after(() => {
+      fs.unlinkSync("config1.js");
+      fs.unlinkSync("config2.js");
+    });
+
+    it("should distinguish between the two files", function () {
+      const result1 = customConfig.resolve("config1.js");
+      assert.deepEqual(result1, resolveConfig({ a: 1 }));
+      const result2 = customConfig.resolve("config2.js");
+      assert.deepEqual(result2, resolveConfig({ a: 2 }));
+    });
+  });
+});


### PR DESCRIPTION
# Resolve issues with loading different config files with the same modification time

## Description

We were experiencing issue #241 and tracked it down to the `customConfig.resolve` function erroneously using the cached config because the two tailwind config files in our project share the same modification time (after a git pull).

Fixes #241 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

We tested this fix by adding unit tests for `customConfig.resolve`.

**Test Configuration**:

- OS + version: macOS Sonoma
- NPM version: 10.8.2
- Node version: 20.18.0

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
