### PR TITLE
fix: load correct tailwind config in monorepo

### DIFF
--- a/lib/util/customConfig.js
+++ b/lib/util/customConfig.js
@@ -48,7 +48,7 @@ function loadConfig(config) {
       if (stats === null) {
         // Default to no config
         loadedConfig = {};
-      } else if (lastModifiedDate !== mtime) {
+      } else if (lastModifiedDate !== mtime || previousConfig !== config) {
         // Load the config based on path
         lastModifiedDate = mtime;
         loadedConfig = requireUncached(resolvedPath);
@@ -86,13 +86,13 @@ function resolve(twConfig) {
   const now = Date.now();
   const expired = now - lastCheck > CHECK_REFRESH_RATE;
   if (newConfig || expired) {
-    previousConfig = twConfig;
-    lastCheck = now;
     const userConfig = loadConfig(twConfig);
     // userConfig is null when config file was not modified
     if (userConfig !== null) {
       mergedConfig = resolveConfig(userConfig);
     }
+    previousConfig = twConfig;
+    lastCheck = now;
   }
   return mergedConfig;
 }


### PR DESCRIPTION
# Pull Request Name

## Description

In the latest flat config, we can set different settings for different files, such as using different tailwind configs for files in different directories. However, the current cache does not handle caching of multiple files well, resulting in the configuration not taking effect, and we are still using the same tailwind configuration.

```
export default [
  {
    settings: {
      tailwindcss: {
        config: path.join(import.meta.dirname, "tailwind.config.ts"),
      },
    },
  },
  {
    files: ["apps/mobile/**/*"],
    settings: {
      tailwindcss: {
        config: path.join(import.meta.dirname, "apps/mobile/tailwind.config.ts"),
      },
    },
  },
]
```

If I'm not thoughtful enough, please let me know.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- OS + version: e.g. macOS Mojave
- NPM version: ...
- Node version: ...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
