### PR TITLE
fix: no-custom-classname false negatives with nativewind

### DIFF
--- a/lib/util/customConfig.js
+++ b/lib/util/customConfig.js
@@ -11,6 +11,9 @@ try {
   twLoadConfig = null;
 }
 
+// for nativewind preset
+process.env.TAILWIND_MODE = 'build';
+
 const CHECK_REFRESH_RATE = 1_000;
 let previousConfig = null;
 let lastCheck = null;


### PR DESCRIPTION
nativewind will return different presets in the tailwind vscode plug-in, which will cause the result of the lint and tailwind plug-in to be inconsistent.

`node_modules/nativewind/dist/tailwind/index.js`

```js
"use strict";
module.exports = Object.assign(() => {
    const isTailwindCSSIntelliSenseMode = "TAILWIND_MODE" in process.env;
    if (isTailwindCSSIntelliSenseMode)
        return require("./native").default;
    return process.env.NATIVEWIND_OS === undefined ||
        process.env.NATIVEWIND_OS === "web"
        ? require("./web").default
        : require("./native").default;
}, {
    nativewind: true,
});
//# sourceMappingURL=index.js.map
```