### PR TITLE
feat: support `satisfies` operator in TypeScript

### DIFF
--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -164,6 +164,9 @@ module.exports = {
             suffix = astUtil.getTemplateElementSuffix(txt, originalClassNamesValue);
             originalClassNamesValue = astUtil.getTemplateElementBody(txt, prefix, suffix);
             break;
+          case 'TSSatisfiesExpression':
+            sortNodeArgumentValue(node, arg.expression);
+            break;
         }
       }
 

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -126,6 +126,9 @@ module.exports = {
               return;
             }
             break;
+          case 'TSSatisfiesExpression':
+            parseForNegativeArbitraryClassNames(node, arg.expression);
+            return;
         }
       }
 

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -233,6 +233,9 @@ module.exports = {
             suffix = astUtil.getTemplateElementSuffix(txt, originalClassNamesValue);
             originalClassNamesValue = astUtil.getTemplateElementBody(txt, prefix, suffix);
             break;
+          case 'TSSatisfiesExpression':
+            parseForShorthandCandidates(node, arg.expression);
+            return;
         }
       }
 

--- a/lib/rules/migration-from-tailwind-2.js
+++ b/lib/rules/migration-from-tailwind-2.js
@@ -153,6 +153,9 @@ module.exports = {
             suffix = astUtil.getTemplateElementSuffix(txt, originalClassNamesValue);
             originalClassNamesValue = astUtil.getTemplateElementBody(txt, prefix, suffix);
             break;
+          case 'TSSatisfiesExpression':
+            parseForObsoleteClassNames(node, arg.expression);
+            return;
         }
       }
 

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -126,6 +126,9 @@ module.exports = {
               return;
             }
             break;
+          case 'TSSatisfiesExpression':
+            parseForArbitraryValues(node, arg.expression);
+            return;
         }
       }
 

--- a/lib/rules/no-unnecessary-arbitrary-value.js
+++ b/lib/rules/no-unnecessary-arbitrary-value.js
@@ -165,6 +165,9 @@ module.exports = {
               }
             }
             break;
+          case 'TSSatisfiesExpression':
+            parseForArbitraryValues(node, arg.expression);
+            return;
         }
       }
 

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -331,6 +331,9 @@ function parseNodeRecursive(rootNode, childNode, cb, skipConditional = false, is
       case 'TemplateElement':
         originalClassNamesValue = childNode.value.raw;
         break;
+      case 'TSSatisfiesExpression':
+        parseNodeRecursive(rootNode, childNode.expression, cb, skipConditional, isolate, ignoredKeys);
+        return;
     }
     ({ classNames } = extractClassnamesFromValue(originalClassNamesValue));
     classNames = removeDuplicatesFromArray(classNames);

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "mocha": "^10.2.0",
         "semver": "^7.6.0",
         "tailwindcss": "^3.4.0",
-        "typescript": "4.3.5",
+        "typescript": "4.9.5",
         "vue-eslint-parser": "^9.4.2"
       },
       "engines": {
@@ -2650,9 +2650,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4712,9 +4712,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mocha": "^10.2.0",
     "semver": "^7.6.0",
     "tailwindcss": "^3.4.0",
-    "typescript": "4.3.5",
+    "typescript": "4.9.5",
     "vue-eslint-parser": "^9.4.2"
   },
   "packageManager": "npm@10.2.5+sha256.8002e3e7305d2abd4016e1368af48d49b066c269079eeb10a56e7d6598acfdaa",

--- a/tests/lib/rules/classnames-order.js
+++ b/tests/lib/rules/classnames-order.js
@@ -328,6 +328,42 @@ ruleTester.run("classnames-order", rule, {
       errors: errors,
     },
     {
+      code: `
+      export interface FakePropsInterface {
+        readonly name?: string;
+      }
+      function Fake({
+        name = 'yolo'
+      }: FakeProps) {
+        return (
+          <>
+            <h1 className={"absolute bottom-0 w-full flex flex-col" satisfies string}>Welcome {name}</h1>
+            <p>Bye {name}</p>
+          </>
+        );
+      }
+      export default Fake;
+      `,
+      output: `
+      export interface FakePropsInterface {
+        readonly name?: string;
+      }
+      function Fake({
+        name = 'yolo'
+      }: FakeProps) {
+        return (
+          <>
+            <h1 className={"absolute bottom-0 flex w-full flex-col" satisfies string}>Welcome {name}</h1>
+            <p>Bye {name}</p>
+          </>
+        );
+      }
+      export default Fake;
+      `,
+      parser: require.resolve("@typescript-eslint/parser"),
+      errors: errors,
+    },
+    {
       code: `<div class="sm:w-6 container w-12">Classnames will be ordered</div>`,
       output: `<div class="container w-12 sm:w-6">Classnames will be ordered</div>`,
       errors: errors,

--- a/tests/lib/rules/enforces-negative-arbitrary-values.js
+++ b/tests/lib/rules/enforces-negative-arbitrary-values.js
@@ -97,6 +97,13 @@ ruleTester.run("enforces-negative-arbitrary-values", rule, {
       ),
     },
     {
+      code: `<div class={"-inset-[1px] -inset-y-[1px] -inset-x-[1px] -top-[1px] -right-[1px] -bottom-[1px] -left-[1px] -top-[1px] -z-[2] -order-[2] -m-[1px] -my-[1px] -mx-[1px] -mt-[1px] -mr-[1px] -mb-[1px] -ml-[1px] -mt-[1px] -space-y-[1px] -space-x-[1px] -tracking-[1px] -indent-[1px] -hue-rotate-[50%] -backdrop-hue-rotate-[50%] -scale-[50%] -scale-y-[50%] -scale-x-[50%] -rotate-[45deg] -translate-x-[1px] -translate-y-[1px] -skew-x-[45deg] -skew-y-[45deg] -scroll-m-[1px] -scroll-my-[1px] -scroll-mx-[1px] -scroll-mt-[1px] -scroll-mr-[1px] -scroll-mb-[1px] -scroll-ml-[1px] -scroll-mt-[1px]" satisfies string}>all</div>`,
+      parser: require.resolve("@typescript-eslint/parser"),
+      errors: generateErrors(
+        "-inset-[1px] -inset-y-[1px] -inset-x-[1px] -top-[1px] -right-[1px] -bottom-[1px] -left-[1px] -top-[1px] -z-[2] -order-[2] -m-[1px] -my-[1px] -mx-[1px] -mt-[1px] -mr-[1px] -mb-[1px] -ml-[1px] -mt-[1px] -space-y-[1px] -space-x-[1px] -tracking-[1px] -indent-[1px] -hue-rotate-[50%] -backdrop-hue-rotate-[50%] -scale-[50%] -scale-y-[50%] -scale-x-[50%] -rotate-[45deg] -translate-x-[1px] -translate-y-[1px] -skew-x-[45deg] -skew-y-[45deg] -scroll-m-[1px] -scroll-my-[1px] -scroll-mx-[1px] -scroll-mt-[1px] -scroll-mr-[1px] -scroll-mb-[1px] -scroll-ml-[1px] -scroll-mt-[1px]"
+      ),
+    },
+    {
       code: `
       <template>
         <div class="-inset-[1px] -inset-y-[1px]" />

--- a/tests/lib/rules/enforces-shorthand.js
+++ b/tests/lib/rules/enforces-shorthand.js
@@ -600,6 +600,20 @@ ruleTester.run("shorthands", rule, {
     },
     {
       code: `
+      <div class={"mt-0 mr-0 mb-0 ml-1" satisfies string}>
+        Possible shorthand for margin
+      </div>
+      `,
+      output: `
+      <div class={"my-0 mr-0 ml-1" satisfies string}>
+        Possible shorthand for margin
+      </div>
+      `,
+      parser: require.resolve("@typescript-eslint/parser"),
+      errors: [generateError(["mt-0", "mb-0"], "my-0")],
+    },
+    {
+      code: `
       <template>
         <div class="overflow-x-auto overflow-y-auto block md:p-0 px-0 py-[0]">
           Possible shorthand for overflow

--- a/tests/lib/rules/migration-from-tailwind-2.js
+++ b/tests/lib/rules/migration-from-tailwind-2.js
@@ -287,6 +287,19 @@ ruleTester.run("migration-from-tailwind-2", rule, {
       ],
     },
     {
+      code: `<div class={"transform scale-50" satisfies string}>Automatic transform</div>`,
+      output: `<div class={"scale-50" satisfies string}>Automatic transform</div>`,
+      parser: require.resolve("@typescript-eslint/parser"),
+      errors: [
+        {
+          messageId: "classnameNotNeeded",
+          data: {
+            classnames: "transform",
+          },
+        },
+      ],
+    },
+    {
       code: `
       <template>
         <span class="placeholder-red-900" />

--- a/tests/lib/rules/no-arbitrary-value.js
+++ b/tests/lib/rules/no-arbitrary-value.js
@@ -136,6 +136,11 @@ ruleTester.run("no-arbitrary-value", rule, {
       errors: generateErrors("w-[10px]"),
     },
     {
+      code: `<div class={"w-[10px]" satisfies string}>Arbitrary width!</div>`,
+      parser: require.resolve("@typescript-eslint/parser"),
+      errors: generateErrors("w-[10px]"),
+    },
+    {
       code: `
       <script>
       export default {

--- a/tests/lib/rules/no-contradicting-classname.js
+++ b/tests/lib/rules/no-contradicting-classname.js
@@ -343,6 +343,29 @@ ruleTester.run("no-contradicting-classname", rule, {
       errors: generateErrors("w-1 w-2"),
     },
     {
+      code: `
+      export interface FakePropsInterface {
+        readonly name?: string;
+      }
+
+      function Fake({
+        name = 'yolo'
+      }: FakeProps) {
+
+        return (
+          <>
+            <h1 className={"container w-1 w-2" satisfies string}>Welcome {name}</h1>
+            <p>Bye {name}</p>
+          </>
+        );
+      }
+
+      export default Fake;
+      `,
+      parser: require.resolve("@typescript-eslint/parser"),
+      errors: generateErrors("w-1 w-2"),
+    },
+    {
       code: '<div class="container w-1 w-2"></div>',
       errors: generateErrors("w-1 w-2"),
     },

--- a/tests/lib/rules/no-custom-classname.js
+++ b/tests/lib/rules/no-custom-classname.js
@@ -1148,6 +1148,26 @@ ruleTester.run("no-custom-classname", rule, {
       errors: generateErrors("my-custom"),
     },
     {
+      code: `
+      export interface FakePropsInterface {
+        readonly name?: string;
+      }
+      function Fake({
+        name = 'yolo'
+      }: FakeProps) {
+        return (
+          <>
+            <h1 className={"w-12 my-custom" satisfies string}>Welcome {name}</h1>
+            <p>Bye {name}</p>
+          </>
+        );
+      }
+      export default Fake;
+      `,
+      parser: require.resolve("@typescript-eslint/parser"),
+      errors: generateErrors("my-custom"),
+    },
+    {
       code: `<div class="w-12 my-custom">my-custom is not defined in Tailwind CSS!</div>`,
       errors: generateErrors("my-custom"),
     },

--- a/tests/lib/rules/no-unnecessary-arbitrary-value.js
+++ b/tests/lib/rules/no-unnecessary-arbitrary-value.js
@@ -268,5 +268,16 @@ ruleTester.run("arbitrary-values", rule, {
       options: config,
       errors: generateErrors(["border-[1px]", "rounded-[0.25rem]"], [["border"], ["rounded"]]),
     },
+    {
+      code: `
+      <pre class={"-z-[-10]" satisfies string}>z-10</pre>
+      `,
+      output: `
+      <pre class={"z-10" satisfies string}>z-10</pre>
+      `,
+      options: config,
+      parser: require.resolve("@typescript-eslint/parser"),
+      errors: generateErrors(["-z-[-10]"], [["z-10"]]),
+    },
   ],
 });


### PR DESCRIPTION
# Support `satisfies` operator in TypeScript

## Description

This PR adds support for the `satisfies` operator to each rule in the plugin.
It also upgrades TypeScript to 4.9 to use `satisfies` and adds test cases for `satisfies`.

Fixes #396 
Please see this issue for more details.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] `npm run test`

**Test Configuration**:

- OS + version: macOS Sequoia 15.3.2
- NPM version: 8.19.2
- Node version: 18.12.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas -> seems unnecessary
- [ ] I have made corresponding changes to the documentation -> seems unnecessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings