### PR TITLE
add regex whitelist to no-arbitrary-values

### DIFF
--- a/docs/rules/no-arbitrary-value.md
+++ b/docs/rules/no-arbitrary-value.md
@@ -75,7 +75,7 @@ Optional, can be used to support custom attributes
 
 ### `whitelist` (default: `[]`)
 
-The `whitelist` is empty by default but you can add custom regular expressions to this array to avoid getting warnings or errors while using certain arbitrary values or tailwind classes.
+The `whitelist` is empty by default but you can add custom regular expressions to this array to avoid getting warnings or errors while using arbitrary values for certain tailwind classes.
 
 For example, if we want to whitelist 'text-' classes for pixel values only and all 'h-" classes the `whitelist` options should be set to:
 

--- a/docs/rules/no-arbitrary-value.md
+++ b/docs/rules/no-arbitrary-value.md
@@ -28,6 +28,7 @@ Examples of **correct** code for this rule:
   "config": <string>|<object>,
   "skipClassAttribute": <boolean>,
   "tags": Array<string>,
+  "whitelist": Array<string>,
 }]
 ...
 ```
@@ -71,6 +72,14 @@ Optional, if you are using tagged templates, you should provide the tags in this
 ### `classRegex` (default: `"^class(Name)?$"`)
 
 Optional, can be used to support custom attributes
+
+### `whitelist` (default: `[]`)
+
+The `whitelist` is empty by default but you can add custom regular expressions to this array to avoid getting warnings or errors while using certain arbitrary values or tailwind classes.
+
+For example, if we want to whitelist 'text-' classes for pixel values only and all 'h-" classes the `whitelist` options should be set to:
+
+- `['text-\\[\\d*px]', 'h-\\[[^\\]]*]']`
 
 ## Further Reading
 

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -137,13 +137,8 @@ module.exports = {
 
       let { classNames } = astUtil.extractClassnamesFromValue(originalClassNamesValue);
       const forbidden = [];
-      console.log(classNames);
       classNames.forEach((cls, idx) => {
         const parsed = groupUtil.parseClassname(cls, [], mergedConfig, idx);
-        console.log('whitelist');
-        console.log(whitelist);
-        console.log('parsed.body');
-        console.log(parsed.body);
         const whitelistIdx = groupUtil.getGroupIndex(parsed.body, whitelist, mergedConfig.separator);
         if (whitelistIdx < 0 && /\[.*\]/i.test(parsed.body)) {
           forbidden.push(parsed.name);

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -54,6 +54,11 @@ module.exports = {
             items: { type: 'string', minLength: 0 },
             uniqueItems: true,
           },
+          whitelist: {
+            type: 'array',
+            items: { type: 'string', minLength: 0 },
+            uniqueItems: true,
+          },
         },
       },
     ],
@@ -65,6 +70,7 @@ module.exports = {
     const tags = getOption(context, 'tags');
     const twConfig = getOption(context, 'config');
     const classRegex = getOption(context, 'classRegex');
+    const whitelist = getOption(context, 'whitelist');
 
     const mergedConfig = customConfig.resolve(twConfig);
 
@@ -131,9 +137,15 @@ module.exports = {
 
       let { classNames } = astUtil.extractClassnamesFromValue(originalClassNamesValue);
       const forbidden = [];
+      console.log(classNames);
       classNames.forEach((cls, idx) => {
         const parsed = groupUtil.parseClassname(cls, [], mergedConfig, idx);
-        if (/\[.*\]/i.test(parsed.body)) {
+        console.log('whitelist');
+        console.log(whitelist);
+        console.log('parsed.body');
+        console.log(parsed.body);
+        const whitelistIdx = groupUtil.getGroupIndex(parsed.body, whitelist, mergedConfig.separator);
+        if (whitelistIdx < 0 && /\[.*\]/i.test(parsed.body)) {
           forbidden.push(parsed.name);
         }
       });

--- a/tests/lib/rules/no-arbitrary-value.js
+++ b/tests/lib/rules/no-arbitrary-value.js
@@ -163,7 +163,20 @@ ruleTester.run("no-arbitrary-value", rule, {
       code: `<div className={'min-h-[75dvh]'}>Dynamic viewport units</div>`,
       errors: generateErrors(["min-h-[75dvh]"]),
     },
-    ...(['myTag', 'myTag.subTag', 'myTag(SomeComponent)'].map(tag => ({
+    {
+      code: `
+        <nav
+          className={classnames("text-[12px] text-[#ffffff] h-[50px] w-[100px] bg-[red] bg-[#ffff00] m-[5px] min-h-[30px] py-[8px] border-[2px]")}
+        />`,
+      errors: generateErrors("p-[3px]"),
+      options: [
+        {
+          whitelist: ["text-\\[\\d*px]", "bg-\\[[a-zA-Z]+]", "h-\\[[^\\]]*]"],
+        },
+      ],
+      errors: generateErrors("text-[#ffffff] w-[100px] bg-[#ffff00] m-[5px] min-h-[30px] py-[8px] border-[2px]"),
+    },
+    ...["myTag", "myTag.subTag", "myTag(SomeComponent)"].map((tag) => ({
       code: `${tag}\`w-[100px]\``,
       errors: generateErrors("w-[100px]"),
       options: [
@@ -171,6 +184,6 @@ ruleTester.run("no-arbitrary-value", rule, {
           tags: ["myTag"],
         },
       ],
-    }))),
+    })),
   ],
 });


### PR DESCRIPTION
# Pull Request Name
Add a whitelist for no-arbitrary-values rule

## Description
I'm using the no-arbitrary-values rule to enforce team consistency with a design system. Our design system is not opinionated on a subset of tailwind classes though (mostly height and width related) so I would like to whitelist those sort of classes to allow for arbitrary values. See similar asks from these two issues

https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/286
https://github.com/francoismassart/eslint-plugin-tailwindcss/issues/247

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
I added a unit test with various whitelist options to make sure the change works. I also made sure the regex would allow users to specify the content within the arbitrary values. I,e whitelisting 'text-[12px]' but disallowing 'text-[#ffffff]' 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
