### PR TITLE
Fix YouTube channel URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can can the same information on your favorite command line software as well.
 
 ## Screencasts on our YouTube Channel
 
-| <a href="https://www.youtube.com/@eslint-plugin-tailwind-css"><img src=".github/youtube-eslint-plugin-tailwindcss-round.png" width="80" height="80" alt="YouTube Channel" /></a> | <span style="font-size:18px">[ESLint plugin Tailwind CSS](https://www.youtube.com/@eslint-plugin-tailwind-css)</span><br>youtube.com/@eslint-plugin-tailwindcss |
+| <a href="https://www.youtube.com/@eslint-plugin-tailwindcss"><img src=".github/youtube-eslint-plugin-tailwindcss-round.png" width="80" height="80" alt="YouTube Channel" /></a> | <span style="font-size:18px">[ESLint plugin Tailwind CSS](https://www.youtube.com/@eslint-plugin-tailwindcss)</span><br>youtube.com/@eslint-plugin-tailwindcss |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
 ## Installation


### PR DESCRIPTION
# Pull Request Name

## Description

This fixes the link to the YouTube channel in `README.md` which previously lead to a 404 not found page.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested the new URL manually