### PR TITLE
Add rule type to meta to comply with expected custom rule shape

### DIFF
--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -27,6 +27,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('classnames-order'),
     },
+    type: 'suggestion',
     messages: {
       invalidOrder: INVALID_CLASSNAMES_ORDER_MSG,
     },

--- a/lib/rules/enforces-negative-arbitrary-values.js
+++ b/lib/rules/enforces-negative-arbitrary-values.js
@@ -27,6 +27,7 @@ module.exports = {
       recommended: true,
       url: docsUrl('enforces-negative-arbitrary-values'),
     },
+    type: 'suggestion',
     messages: {
       negativeArbitraryValue: NEGATIVE_ARBITRARY_VALUE,
     },

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -28,6 +28,7 @@ module.exports = {
       recommended: true,
       url: docsUrl('enforces-shorthand'),
     },
+    type: 'suggestion',
     messages: {
       shorthandCandidateDetected: SHORTHAND_CANDIDATE_CLASSNAMES_DETECTED_MSG,
     },

--- a/lib/rules/migration-from-tailwind-2.js
+++ b/lib/rules/migration-from-tailwind-2.js
@@ -30,6 +30,7 @@ module.exports = {
       recommended: true,
       url: docsUrl('migration-from-tailwind-2'),
     },
+    type: 'suggestion',
     messages: {
       classnameNotNeeded: CLASSNAME_NOT_NEEDED_MSG,
       classnamesNotNeeded: CLASSNAMES_NOT_NEEDED_MSG,

--- a/lib/rules/no-arbitrary-value.js
+++ b/lib/rules/no-arbitrary-value.js
@@ -27,6 +27,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-arbitrary-value'),
     },
+    type: 'suggestion',
     messages: {
       arbitraryValueDetected: ARBITRARY_VALUE_DETECTED_MSG,
     },

--- a/lib/rules/no-contradicting-classname.js
+++ b/lib/rules/no-contradicting-classname.js
@@ -28,6 +28,7 @@ module.exports = {
       recommended: true,
       url: docsUrl('no-contradicting-classname'),
     },
+    type: 'suggestion',
     messages: {
       conflictingClassnames: CONFLICTING_CLASSNAMES_DETECTED_MSG,
     },

--- a/lib/rules/no-custom-classname.js
+++ b/lib/rules/no-custom-classname.js
@@ -38,6 +38,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-custom-classname'),
     },
+    type: 'suggestion',
     messages: {
       customClassnameDetected: CUSTOM_CLASSNAME_DETECTED_MSG,
     },

--- a/lib/rules/no-unnecessary-arbitrary-value.js
+++ b/lib/rules/no-unnecessary-arbitrary-value.js
@@ -33,6 +33,7 @@ module.exports = {
       recommended: true,
       url: docsUrl('no-unnecessary-arbitrary-value'),
     },
+    type: 'suggestion',
     messages: {
       unnecessaryArbitraryValueDetected: UNNECESSARY_ARBITRARY_VALUE_DETECTED_MSG,
     },


### PR DESCRIPTION
# Pull Request Name

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Eslint expects a certain structure, of which meta.type is expected: https://eslint.org/docs/latest/extend/custom-rules#rule-structure

This powers the ESLint cli (or node API) functionality to filter by a type of rule when fixing. https://eslint.org/docs/latest/use/command-line-interface#--fix-type When nothing is specified, the rule cannot be selected for at all.

I selected the type of "suggestion" for which the definition is:
> The rule is identifying something that could be done in a better way but no errors will occur if the code isn’t changed.

I believe all the rules here, while possibly strong suggestions, are suggestions when read in this manner.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran the supplied tests and they still pass, as well as I made the corollary updates to a project that was showing violations of this rule which were not previous fixable, and now are fixable.

**Test Configuration**:

- OS + version: e.g. macOS Sequoia 15.7.1
- NPM version: 10.8.2
- Node version: v20.19.5

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
