### PR TITLE
fix(rule): no-unnecessary-arbitrary-value

### DIFF
--- a/lib/rules/no-unnecessary-arbitrary-value.js
+++ b/lib/rules/no-unnecessary-arbitrary-value.js
@@ -82,6 +82,34 @@ module.exports = {
     //----------------------------------------------------------------------
 
     /**
+     * Flatten nested configuration object into a map of key paths to values
+     * @param {Object} obj The configuration object to flatten
+     * @param {String} prefix The prefix for the current path
+     * @param {Object} result The accumulated result object
+     * @returns {Object} A map where keys are dot-separated paths and values are config values
+     */
+    const flattenConfig = (obj, prefix = '', result = {}) => {
+      if (typeof obj !== 'object' || obj === null) {
+        return result;
+      }
+
+      Object.keys(obj).forEach((key) => {
+        const value = obj[key];
+        const newKey = prefix ? `${prefix}.${key}` : key;
+
+        if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+          // Recursively flatten nested objects
+          flattenConfig(value, newKey, result);
+        } else {
+          // Store the leaf value
+          result[newKey] = value;
+        }
+      });
+
+      return result;
+    };
+
+    /**
      * Recursive function crawling into child nodes
      * @param {ASTNode} node The root node of the current parsing
      * @param {ASTNode} arg The child node of node
@@ -197,12 +225,16 @@ module.exports = {
           if ([undefined, null].includes(configuration)) {
             return false;
           }
-          const configurationKeys = Object.keys(configuration);
+
+          // Flatten the configuration to handle nested objects (e.g., colors.foreground.positive)
+          const flattenedConfig = flattenConfig(configuration);
+          const configurationKeys = Object.keys(flattenedConfig);
+
           const zeroValueWithOrWithoutUnitsPattern = new RegExp(validZeroRegEx, 'i');
           const isZeroArbitraryValue = zeroValueWithOrWithoutUnitsPattern.test(arbitraryValue);
           const negativeSubstitutes = [];
           const matchingConfigurationKeys = configurationKeys.filter((key) => {
-            const configValue = configuration[key];
+            const configValue = flattenedConfig[key];
             if (isZeroArbitraryValue && zeroValueWithOrWithoutUnitsPattern.test(configValue)) {
               // Both config and tested values are 0 based (with or without units)
               negativeSubstitutes.push(false);
@@ -232,10 +264,15 @@ module.exports = {
                 let patchedBody = backBone.substring(parsed.variants.length);
                 patchedBody = patchedBody.charAt(0) === '-' ? patchedBody.substring(1) : patchedBody;
                 const noneOrMinus = negativeSubstitutes[idx] ? '-' : '';
+
+                // Convert dot-separated paths to dash-separated class names
+                // e.g., 'foreground.positive' becomes 'foreground-positive'
+                const classNameSuffix = key.replace(/\./g, '-');
+
                 if (key === 'DEFAULT') {
                   return parsed.variants + noneOrMinus + patchedBody.substring(0, patchedBody.length - 1);
                 }
-                return parsed.variants + noneOrMinus + patchedBody + key;
+                return parsed.variants + noneOrMinus + patchedBody + classNameSuffix;
               })
             );
           }

--- a/lib/rules/no-unnecessary-arbitrary-value.js
+++ b/lib/rules/no-unnecessary-arbitrary-value.js
@@ -98,10 +98,8 @@ module.exports = {
         const newKey = prefix ? `${prefix}.${key}` : key;
 
         if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-          // Recursively flatten nested objects
           flattenConfig(value, newKey, result);
         } else {
-          // Store the leaf value
           result[newKey] = value;
         }
       });

--- a/tests/lib/rules/no-unnecessary-arbitrary-value.js
+++ b/tests/lib/rules/no-unnecessary-arbitrary-value.js
@@ -28,6 +28,18 @@ var config = [
   {
     config: {
       theme: {
+        colors: {
+          primary: "#8000ff",
+          foreground: {
+            positive: "#6eff00",
+          },
+          background: {
+            positive: "#6eff00",
+          },
+          action: {
+            primary: "#ff5733",
+          },
+        },
         extend: {
           spacing: {
             spacing: "99px",
@@ -70,6 +82,36 @@ ruleTester.run("arbitrary-values", rule, {
     },
     {
       code: `
+      <pre class="text-foreground-positive">text-foreground-positive</pre>
+      `,
+      options: config,
+    },
+    {
+      code: `
+      <pre class="text-background-positive">text-background-positive</pre>
+      `,
+      options: config,
+    },
+    {
+      code: `
+      <pre class="bg-action-primary">bg-action-primary</pre>
+      `,
+      options: config,
+    },
+    {
+      code: `
+      <pre class="text-primary">text-primary</pre>
+      `,
+      options: config,
+    },
+    {
+      code: `
+      <pre class="text-[#58cc00]">arbitrary hex color</pre>
+      `,
+      options: config,
+    },
+    {
+      code: `
       <pre class="![clip:rect(0,0,0,0)]">issue #317</pre>
       `,
       options: config,
@@ -103,6 +145,33 @@ ruleTester.run("arbitrary-values", rule, {
       `,
       options: config,
       errors: generateErrors(["h-[0]"], [["h-0", "h-zerodotzero", "h-none", "h-zeropx"]]),
+    },
+    {
+      code: `
+      <pre class="text-[#6eff00]">text with multiple matches</pre>
+      `,
+      options: config,
+      errors: generateErrors(["text-[#6eff00]"], [["text-foreground-positive", "text-background-positive"]]),
+    },
+    {
+      code: `
+      <pre class="bg-[#ff5733]">bg with single match</pre>
+      `,
+      output: `
+      <pre class="bg-action-primary">bg with single match</pre>
+      `,
+      options: config,
+      errors: generateErrors(["bg-[#ff5733]"], [["bg-action-primary"]]),
+    },
+    {
+      code: `
+      <pre class="text-[#8000ff]">simple flat color key</pre>
+      `,
+      output: `
+      <pre class="text-primary">simple flat color key</pre>
+      `,
+      options: config,
+      errors: generateErrors(["text-[#8000ff]"], [["text-primary"]]),
     },
     {
       code: `


### PR DESCRIPTION
# Pull Request Name
fix(rule): no-unnecessary-arbitrary-value

## Description
Fix issue where `no-unnecessary-arbitrary-value` would allow arbitrary hex color values even when a valid tailwind class alternative was already available as part of the theme. Add passing/failing tests for the updated hex color checks.

Motivation:
While doing some local development I noticed that the rule as it exists on `master` can properly catch arbitrary values such as margins/padding, but it fails to catch arbitrary colors even if theres a valid alternative available in the user's TW theme/config.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- Added passing AND failing tests for custom tailwind theme colors
  - Also included tests for "single match" (autofixable) as well as multi-match (developer must choose between multiple potential fixes)

**Test Configuration**:

- OS + version: macOS Sequoia 15.7.2
- NPM version: 8.19.2
- Node version: 18.12.0

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
