### PR TITLE
feat: support eslint v10 by replacing deprecated context methods

### DIFF
--- a/lib/rules/classnames-order.js
+++ b/lib/rules/classnames-order.js
@@ -147,7 +147,7 @@ module.exports = {
             // The problem is that range computation includes the backticks (`test`)
             // but value.raw does not include them, so there is a mismatch.
             // start/end does not include the backticks, therefore it matches value.raw.
-            const txt = context.getSourceCode().getText(arg);
+            const txt = context.sourceCode.getText(arg);
             prefix = astUtil.getTemplateElementPrefix(txt, originalClassNamesValue);
             suffix = astUtil.getTemplateElementSuffix(txt, originalClassNamesValue);
             originalClassNamesValue = astUtil.getTemplateElementBody(txt, prefix, suffix);

--- a/lib/rules/enforces-shorthand.js
+++ b/lib/rules/enforces-shorthand.js
@@ -228,7 +228,7 @@ module.exports = {
             // The problem is that range computation includes the backticks (`test`)
             // but value.raw does not include them, so there is a mismatch.
             // start/end does not include the backticks, therefore it matches value.raw.
-            const txt = context.getSourceCode().getText(arg);
+            const txt = context.sourceCode.getText(arg);
             prefix = astUtil.getTemplateElementPrefix(txt, originalClassNamesValue);
             suffix = astUtil.getTemplateElementSuffix(txt, originalClassNamesValue);
             originalClassNamesValue = astUtil.getTemplateElementBody(txt, prefix, suffix);

--- a/lib/rules/migration-from-tailwind-2.js
+++ b/lib/rules/migration-from-tailwind-2.js
@@ -148,7 +148,7 @@ module.exports = {
             // The problem is that range computation includes the backticks (`test`)
             // but value.raw does not include them, so there is a mismatch.
             // start/end does not include the backticks, therefore it matches value.raw.
-            const txt = context.getSourceCode().getText(arg);
+            const txt = context.sourceCode.getText(arg);
             prefix = astUtil.getTemplateElementPrefix(txt, originalClassNamesValue);
             suffix = astUtil.getTemplateElementSuffix(txt, originalClassNamesValue);
             originalClassNamesValue = astUtil.getTemplateElementBody(txt, prefix, suffix);

--- a/lib/util/parser.js
+++ b/lib/util/parser.js
@@ -22,7 +22,7 @@ function defineTemplateBodyVisitor(context, templateBodyVisitor, scriptVisitor) 
  * @see https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#from-context-to-sourcecode
  */
 function getParserServices(context) {
-  return context.sourceCode ? context.sourceCode.parserServices : context.parserServices;
+  return context.sourceCode.parserServices;
 }
 
 module.exports = {


### PR DESCRIPTION
# Pull Request Name

## Description

ESLint 10 has been released and removed several deprecated rule context members. See the full list of removed APIs here: https://eslint.org/blog/2026/02/eslint-v10.0.0-released/#removed-deprecated-rule-context-members                                                                         

This PR replaces all usages of context.getSourceCode() with the modern context.sourceCode property.                                                                      

After this change, the minimum supported ESLint version is v8.40.0, which was released three years ago. If support for versions below v8.40.0 is still needed, please let  me know.

Closed #439

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

**Test Configuration**:

- OS + version: macOS 15.6.1
- NPM version: 11.4.2
- Node version: 22.14.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
