### PR TITLE
feat: add cn tagFunction from shadcn

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You should specify settings that will be shared across all the plugin rules. ([M
       // REQUIRED, default value will not help
       cssConfigPath: dirname(fileURLToPath(import.meta.url)) + "/styles/tailwind.css",
       // Functions/tagFunctions that will be parsed by the plugin.
-      // Optional, default values: ["classnames", "clsx", "ctl", "cva", "tv", "tw"]
+      // Optional, default values: ["classnames", "clsx", "ctl", "cva", "tv", "tw", "cn"]
       functions: ["twClasses"]
     },
   }

--- a/src/utils/parse-plugin-settings.ts
+++ b/src/utils/parse-plugin-settings.ts
@@ -41,6 +41,8 @@ export const DEFAULT_SETTINGS: PluginSettings = {
     "cva",
     // @see https://www.npmjs.com/package/tailwind-variants
     "tv",
+    // @see https://www.npmjs.com/package/shadcn
+    "cn",
     // Template Literals or custom function
     "tw",
   ],


### PR DESCRIPTION
# Add `cn` tagFunction from shadcn

## Description

Just wanted to add it upstream since shadcn is enjoying this popularity lately, I think its a big part of pushing forward v4. (I can create a PR for v3 if needed).

Obviously it's a very small change that I think a lot of people have thought, so let me know if there a reason for not doing it and feel free to reject it, no hard feelings.

Thanks for the amazing job :)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Works when I add it in my `eslint.config.mjs`
```ts
{
  settings: {
    tailwindcss: {
      // ....
      functions: ["cn"]
    },
  }
}
```

**Test Configuration**:

- OS + version: macOS Tahoe
- NPM version: 11.x
- Node version: 24.x

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
