### PR TITLE
feat: enforces-negative-arbitrary-values

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
-| Name                                                                   | Description                                                                         | 💼  | ⚠️  | 🔧  | 💡  |
-| :--------------------------------------------------------------------- | :---------------------------------------------------------------------------------- | :-- | :-- | :-- | :-- |
-| [classnames-order](docs/rules/classnames-order.md)                     | Enforces a consistent order for the Tailwind CSS classnames, based on the compiler. |     | ✅  | 🔧  |     |
-| [enforces-shorthand](docs/rules/enforces-shorthand.md)                 | Avoid using multiple Tailwind CSS classnames when not required.                     |     | ✅  | 🔧  |     |
-| [no-contradicting-classname](docs/rules/no-contradicting-classname.md) | Avoid contradicting Tailwind CSS classnames.                                        | ✅  |     |     | 💡  |
-| [no-custom-classname](docs/rules/no-custom-classname.md)               | Detects classnames which do not belong to Tailwind CSS.                             |     | ✅  |     | 💡  |
+| Name                                                                                   | Description                                                                         | 💼  | ⚠️  | 🔧  | 💡  |
+| :------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------- | :-- | :-- | :-- | :-- |
+| [classnames-order](docs/rules/classnames-order.md)                                     | Enforces a consistent order for the Tailwind CSS classnames, based on the compiler. |     | ✅  | 🔧  |     |
+| [enforces-negative-arbitrary-values](docs/rules/enforces-negative-arbitrary-values.md) | Warns about `-` prefixed classnames using arbitrary values.                         |     | ✅  | 🔧  |     |
+| [enforces-shorthand](docs/rules/enforces-shorthand.md)                                 | Avoid using multiple Tailwind CSS classnames when not required.                     |     | ✅  | 🔧  |     |
+| [no-contradicting-classname](docs/rules/no-contradicting-classname.md)                 | Avoid contradicting Tailwind CSS classnames.                                        | ✅  |     |     | 💡  |
+| [no-custom-classname](docs/rules/no-custom-classname.md)                               | Detects classnames which do not belong to Tailwind CSS.                             |     | ✅  |     | 💡  |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/enforces-negative-arbitrary-values.md
+++ b/docs/rules/enforces-negative-arbitrary-values.md
@@ -1,0 +1,43 @@
+# Warns about `-` prefixed classnames using arbitrary values
+
+⚠️ This rule _warns_ in the ✅ `recommended` config.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<section class="-m-[-5px]">
+  <pre class="-z-[1]">enforces-negative-arbitrary-values</pre>
+</section>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<section class="m-[5px]">
+  <pre class="z-[-1]">enforces-negative-arbitrary-values</pre>
+</section>
+```
+
+The first invalid classname `-m-[-5px]` uses a double negation which:
+
+- is harder to read
+- may be the doppelgänger of an already used `m-[-5px]`
+
+The second invalid classname `-z-[1]`:
+
+- feels odd
+- its `z-[-1]` version is nicer
+
+## Options
+
+<!-- begin auto-generated rule options list -->
+
+<!-- end auto-generated rule options list -->
+
+There are no specific options for this rule, yet it uses the general [settings](../../README.md#settings).

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@ import {
   RULE_NAME as CLASSNAMES_ORDER,
 } from "./rules/classnames-order";
 import {
+  enforcesNegativeArbitraryValues,
+  RULE_NAME as ENFORCES_NEGATIVE_ARBITRARY_VALUES,
+} from "./rules/enforces-negative-arbitrary-values";
+import {
   enforcesShorthand,
   RULE_NAME as ENFORCES_SHORTHAND,
 } from "./rules/enforces-shorthand";
@@ -41,6 +45,7 @@ const plugin = {
   },
   rules: {
     [CLASSNAMES_ORDER]: classnamesOrder,
+    [ENFORCES_NEGATIVE_ARBITRARY_VALUES]: enforcesNegativeArbitraryValues,
     [ENFORCES_SHORTHAND]: enforcesShorthand,
     [NO_CUSTOM_CLASSNAME]: noCustomClassname,
     [NO_CONTRADICTING_CLASSNAME]: noContradictingClassname,
@@ -49,6 +54,7 @@ const plugin = {
 
 const recommended = {
   [CLASSNAMES_ORDER]: "warn",
+  [ENFORCES_NEGATIVE_ARBITRARY_VALUES]: "warn",
   [ENFORCES_SHORTHAND]: "warn",
   [NO_CUSTOM_CLASSNAME]: "warn",
   [NO_CONTRADICTING_CLASSNAME]: "error",

--- a/src/rules/enforces-negative-arbitrary-values.spec.ts
+++ b/src/rules/enforces-negative-arbitrary-values.spec.ts
@@ -1,0 +1,123 @@
+import * as Parser from "@typescript-eslint/parser";
+import { RuleTester, TestCaseError } from "@typescript-eslint/rule-tester";
+
+import { generalSettings } from "../utils/parser/test-helpers";
+import {
+  enforcesNegativeArbitraryValues,
+  type MessageIds,
+  RULE_NAME,
+} from "./enforces-negative-arbitrary-values";
+
+const generateError = (
+  oldClassName: string,
+  newClassName: string,
+): TestCaseError<MessageIds> => {
+  return {
+    messageId: "fix:irregular-negative",
+    data: { oldClassName: oldClassName, newClassName: newClassName },
+  };
+};
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: Parser,
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+  settings: {
+    tailwindcss: {
+      ...generalSettings,
+    },
+  },
+});
+
+type SingleErrorTestCase = {
+  code: string;
+  invalidClass: string;
+  patchedClass: string;
+  output: string;
+};
+
+const singleErrorTestCases: Array<SingleErrorTestCase> = [
+  {
+    code: `ctl('-m-[-10px]')`,
+    invalidClass: "-m-[-10px]",
+    patchedClass: "m-[10px]",
+    output: `ctl('m-[10px]')`,
+  },
+  {
+    code: `ctl('-m-[10px]')`,
+    invalidClass: "-m-[10px]",
+    patchedClass: "m-[-10px]",
+    output: `ctl('m-[-10px]')`,
+  },
+  {
+    code: `ctl('dark:-m-[-10px]')`,
+    invalidClass: "dark:-m-[-10px]",
+    patchedClass: "dark:m-[10px]",
+    output: `ctl('dark:m-[10px]')`,
+  },
+];
+
+type MultipleErrorsTestCase = {
+  code: string;
+  invalidClasses: Array<string>;
+  patchedClasses: Array<string>;
+  outputs: Array<string>;
+};
+
+const multipleErrorsTestCases: Array<MultipleErrorsTestCase> = [
+  {
+    code: `
+        ctl(\`
+          lg:pt-[3px]
+          dark:-m-[-123px]
+          -m-[6px]
+        \`)`,
+    invalidClasses: ["dark:-m-[-123px]", "-m-[6px]"],
+    patchedClasses: ["dark:m-[123px]", "m-[-6px]"],
+    outputs: [
+      `
+        ctl(\`
+          lg:pt-[3px]
+          dark:m-[123px]
+          -m-[6px]
+        \`)`,
+      `
+        ctl(\`
+          lg:pt-[3px]
+          dark:m-[123px]
+          m-[-6px]
+        \`)`,
+    ],
+  },
+];
+
+ruleTester.run(RULE_NAME, enforcesNegativeArbitraryValues, {
+  valid:
+    // JSX
+    ["ctl('m-[-10px]')"].map((testedJsxCode) => ({
+      code: testedJsxCode,
+    })),
+  invalid: [
+    ...singleErrorTestCases.map(
+      ({ code, invalidClass, patchedClass, output }) => ({
+        code: code,
+        errors: [generateError(invalidClass, patchedClass)],
+        output: output,
+      }),
+    ),
+    ...multipleErrorsTestCases.map(
+      ({ code, invalidClasses, patchedClasses, outputs }) => ({
+        code: code,
+        errors: invalidClasses.map((invalidClass, index) =>
+          generateError(invalidClass, patchedClasses[index]),
+        ),
+        output: outputs,
+      }),
+    ),
+  ],
+});

--- a/src/rules/enforces-negative-arbitrary-values.ts
+++ b/src/rules/enforces-negative-arbitrary-values.ts
@@ -1,0 +1,183 @@
+/**
+ * @fileoverview Warns about `-` prefixed classnames using arbitrary values.
+ * @author François Massart
+ */
+
+import { RuleCreator } from "@typescript-eslint/utils/eslint-utils";
+import { RuleContext as TSESLintRuleContext } from "@typescript-eslint/utils/ts-eslint";
+
+import urlCreator from "../url-creator";
+import { joiner } from "../utils/joiner";
+import {
+  parsePluginSettings,
+  PluginSettings,
+} from "../utils/parse-plugin-settings";
+import {
+  getBaseClassname,
+  getModifiersPrefix,
+} from "../utils/parser/classname";
+import {
+  dissectAtomicNode,
+  generateLocForClassname,
+  getClassnamesFromValue,
+} from "../utils/parser/node";
+import { defineVisitors, GenericRuleContext } from "../utils/parser/visitors";
+import {
+  AtomicNode,
+  createScriptVisitors,
+  createTemplateVisitors,
+} from "../utils/rule";
+
+export { ESLintUtils } from "@typescript-eslint/utils";
+
+export const RULE_NAME = "enforces-negative-arbitrary-values";
+
+// Message IDs don't need to be prefixed, I just find it easier to keep track of them this way
+export type MessageIds = "fix:irregular-negative";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export type RuleOptions = {};
+
+type Options = [RuleOptions];
+
+type RuleContext = TSESLintRuleContext<MessageIds, Options>;
+
+// The Rule creator returns a function that is used to create a well-typed ESLint rule
+// The parameter passed into RuleCreator is a URL generator function.
+export const createRule = RuleCreator(urlCreator);
+
+const propertiesPattern = [
+  // inset, inset-x, inset-y, scale, scale-x, scale-y
+  "((inset|scale)(?:-(?:x|y))?)",
+  // simple properties
+  "(m|top|right|bottom|left|z|order|tracking|indent|(backdrop-)?hue-rotate)|(space-(x|y))",
+  // scroll-m, scroll-mx, scroll-my, scroll-mt, scroll-mb, scroll-ml, scroll-mr, scroll-ms, scroll-me, scroll-mbs, scroll-mbe
+  "(scroll-m(?:x|y|s|e|bs|be|t|r|b|l|))",
+  // skew, skew-x, skew-y, translate, translate-x, translate-y, rotate, rotate-x, rotate-y, rotate-z
+  "((skew|translate|rotate)(?:-(?:x|y|z))?)",
+].join("|");
+// Matches classnames that start with '-' and contain arbitrary values (e.g., -m-[10px])
+const regexPattern = [
+  "^",
+  "(?<negative>-)",
+  "(?<property>(" + propertiesPattern + "))",
+  String.raw`-\[(?<arbitraryValue>.*)\]`,
+  "$",
+].join("");
+
+const negativeArbitraryRegEx = new RegExp(regexPattern);
+
+const negativeArbitraryClassnames = (
+  context: RuleContext,
+  settings: PluginSettings,
+  options: RuleOptions,
+  literals: Array<AtomicNode>,
+) => {
+  // console.log(options);
+  const genericContext = context as unknown as GenericRuleContext;
+  for (const node of literals) {
+    const { originalClassNamesValue, start, end, prefix, suffix } =
+      dissectAtomicNode(node, genericContext);
+    // Process the extracted classnames and report
+    const { classNames, whitespaces, headSpace, tailSpace } =
+      getClassnamesFromValue(originalClassNamesValue);
+    for (const [index, targetClassName] of classNames.entries()) {
+      const baseClass = getBaseClassname(targetClassName);
+      const modifiers = getModifiersPrefix(targetClassName);
+      const match = baseClass.match(negativeArbitraryRegEx);
+
+      if (!match?.groups) continue;
+
+      const patchedLoc = generateLocForClassname(
+        node,
+        targetClassName,
+        originalClassNamesValue,
+        genericContext,
+      );
+
+      const { property = "", arbitraryValue = "" } = match.groups;
+      const arbitraryValuePatched = arbitraryValue.startsWith("-")
+        ? arbitraryValue.slice(1)
+        : "-" + arbitraryValue;
+      const patchedClass = `${modifiers}${property}-[${arbitraryValuePatched}]`;
+
+      // Patch the problematic classname
+      classNames[index] = patchedClass;
+
+      // Generates the "cleaned" attribute value
+      let patchedValue = joiner({
+        classNames,
+        whitespaces,
+        headSpace,
+        tailSpace,
+        validator: (candidate) => candidate !== targetClassName,
+      });
+      patchedValue = prefix + patchedValue + suffix;
+
+      context.report({
+        loc: patchedLoc,
+        messageId: "fix:irregular-negative",
+        data: {
+          oldClassName: targetClassName,
+          newClassName: patchedClass,
+        },
+        fix: (fixer) => fixer.replaceTextRange([start, end], patchedValue),
+      });
+    }
+  }
+};
+
+export const enforcesNegativeArbitraryValues = createRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    docs: {
+      description:
+        "Warns about `-` prefixed classnames using arbitrary values.",
+    },
+    hasSuggestions: false,
+    messages: {
+      "fix:irregular-negative": `Replace '{{oldClassName}}' by '{{newClassName}}'`,
+    },
+    fixable: "code",
+    // Schema is also parsed by `eslint-doc-generator`
+    schema: [
+      {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [{}],
+    type: "problem",
+  },
+  /**
+   * About `defaultOptions`:
+   * - `defaultOptions` is not parsed to generate the documentation
+   * - `defaultOptions` is used when options are NOT provided in the rules configuration
+   * - If some configuration is provided as the second argument, `defaultOptions` is ignored completely (not merged)
+   * - In other words, the `defaultOptions` is only used when the rule is used WITHOUT any configuration
+   */
+  defaultOptions: [{}],
+  create: (context, options) => {
+    // Merged settings
+    const settings = parsePluginSettings(context.settings);
+
+    return defineVisitors(
+      context as unknown as Readonly<GenericRuleContext>,
+      // Template visitor is only used within Vue SFC files (inside <template> section).
+      createTemplateVisitors(
+        context,
+        settings,
+        options,
+        negativeArbitraryClassnames,
+      ),
+      // Script visitor is used within both JSX and Vue SFC files (inside <script> section).
+      createScriptVisitors(
+        context,
+        settings,
+        options,
+        negativeArbitraryClassnames,
+      ),
+    );
+  },
+});


### PR DESCRIPTION
# enforces-negative-arbitrary-values

## Description

Detects negative arbitrary value classnames such as `-m-[-5px]` or `-z-[1]` and replaces them:

- `-m-[-5px]` → `m-[5px]`
- `-z-[1]` → `z-[-1]`
