### PR TITLE
feat(rule): `important-modifier-suffix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## `v4.2.0`
+
+### 🚀 Features
+
+New rule [`important-modifier-suffix`](./docs/rules/important-modifier-suffix.md): Makes sure the `!` important modifier is at the end of the class names. The former `!` location (between the modifiers and the class name hes been deprecated).
+
 ## `v4.1.0`
 
 ### 🚀 Features

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 | [classnames-order](docs/rules/classnames-order.md)                                     | Enforces a consistent order for the Tailwind CSS classnames, based on the compiler. |     | ✅  | 🔧  |     |
 | [enforces-negative-arbitrary-values](docs/rules/enforces-negative-arbitrary-values.md) | Warns about `-` prefixed classnames using arbitrary values.                         |     | ✅  | 🔧  |     |
 | [enforces-shorthand](docs/rules/enforces-shorthand.md)                                 | Avoid using multiple Tailwind CSS classnames when not required.                     |     | ✅  | 🔧  |     |
+| [important-modifier-suffix](docs/rules/important-modifier-suffix.md)                   | In v4 you should place the `!` at the very end of the class name.                   |     | ✅  |     |     |
 | [no-arbitrary-value](docs/rules/no-arbitrary-value.md)                                 | Forbid using arbitrary values in classnames.                                        |     |     |     |     |
 | [no-contradicting-classname](docs/rules/no-contradicting-classname.md)                 | Avoid contradicting Tailwind CSS classnames.                                        | ✅  |     |     | 💡  |
 | [no-custom-classname](docs/rules/no-custom-classname.md)                               | Detects classnames which do not belong to Tailwind CSS.                             |     | ✅  |     | 💡  |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 - Best practices & consistency since 2021
 - [Made for Tailwind CSS v4](./CHANGELOG.md#made-for-tailwind-css-v4)
-- [7 rules available](#rules) and more on the way
+- [8 rules available](#rules) and more on the way
 - What's new? [Changelog](./CHANGELOG.md) | [Release notes](https://github.com/francoismassart/eslint-plugin-tailwindcss/releases) | [Roadmap](./ROADMAP.md)
 - [Upgrade guide](./UPGRADE.md) from `v3` to `v4`
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,5 +1,7 @@
 # Be careful when you edit the docs
 
+> NB: the script will only dig into built code, it will not work directly from the TypeScript source files.
+
 ## Each rule's documentation is partially generated
 
 Running `pnpm docs:init` will create new files if needed.

--- a/docs/rules/important-modifier-suffix.md
+++ b/docs/rules/important-modifier-suffix.md
@@ -10,6 +10,26 @@ As explained in the official documentation about the [important modifier](https:
 >
 > In `v4` you should place the `!` at the very end of the class name instead.
 
+**The old way is still supported for compatibility but is deprecated.**
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<h1 class="!block">Demo</h1>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<h1 class="block!">Demo</h1>
+```
+
+### Why using shorthands?
+
+- 🤓 Move **away from deprecated** old way
+
 ## Options
 
 <!-- begin auto-generated rule options list -->

--- a/docs/rules/important-modifier-suffix.md
+++ b/docs/rules/important-modifier-suffix.md
@@ -1,0 +1,19 @@
+# In v4 you should place the `!` at the very end of the class name
+
+⚠️ This rule _warns_ in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+
+As explained in the official documentation about the [important modifier](https://tailwindcss.com/docs/upgrade-guide#the-important-modifier):
+
+> In `v3` you could mark a utility as important by placing an `!` at the beginning of the utility name (but after any variants).
+>
+> In `v4` you should place the `!` at the very end of the class name instead.
+
+## Options
+
+<!-- begin auto-generated rule options list -->
+
+<!-- end auto-generated rule options list -->
+
+There are no specific options for this rule, yet it uses the general [settings](../../README.md#settings).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwindcss",
-  "version": "4.1.0",
+  "version": "4.2.0-beta.0",
   "publishConfig": {
     "publish-branch": "v4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwindcss",
-  "version": "4.2.0-beta.0",
+  "version": "4.2.0-beta.1",
   "publishConfig": {
     "publish-branch": "v4"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,10 @@ import {
   RULE_NAME as ENFORCES_SHORTHAND,
 } from "./rules/enforces-shorthand";
 import {
+  importantModifierSuffix,
+  RULE_NAME as IMPORTANT_MODIFIER_SUFFIX,
+} from "./rules/important-modifier-suffix";
+import {
   noArbitraryValue,
   RULE_NAME as NO_ARBITRARY_VALUE,
 } from "./rules/no-arbitrary-value";
@@ -55,6 +59,7 @@ const plugin = {
     [CLASSNAMES_ORDER]: classnamesOrder,
     [ENFORCES_NEGATIVE_ARBITRARY_VALUES]: enforcesNegativeArbitraryValues,
     [ENFORCES_SHORTHAND]: enforcesShorthand,
+    [IMPORTANT_MODIFIER_SUFFIX]: importantModifierSuffix,
     [NO_ARBITRARY_VALUE]: noArbitraryValue,
     [NO_CUSTOM_CLASSNAME]: noCustomClassname,
     [NO_CONTRADICTING_CLASSNAME]: noContradictingClassname,
@@ -66,6 +71,7 @@ const recommended = {
   [CLASSNAMES_ORDER]: "warn",
   [ENFORCES_NEGATIVE_ARBITRARY_VALUES]: "warn",
   [ENFORCES_SHORTHAND]: "warn",
+  [IMPORTANT_MODIFIER_SUFFIX]: "warn",
   [NO_ARBITRARY_VALUE]: "off",
   [NO_CUSTOM_CLASSNAME]: "warn",
   [NO_CONTRADICTING_CLASSNAME]: "error",

--- a/src/rules/classnames-order.ts
+++ b/src/rules/classnames-order.ts
@@ -30,8 +30,6 @@ import {
   getSortedClassNamesWorker,
 } from "../utils/tailwindcss-api/index";
 
-export { ESLintUtils } from "@typescript-eslint/utils";
-
 export const RULE_NAME = "classnames-order";
 
 // Message IDs don't need to be prefixed, I just find it easier to keep track of them this way

--- a/src/rules/enforces-negative-arbitrary-values.ts
+++ b/src/rules/enforces-negative-arbitrary-values.ts
@@ -28,8 +28,6 @@ import {
   createTemplateVisitors,
 } from "../utils/rule";
 
-export { ESLintUtils } from "@typescript-eslint/utils";
-
 export const RULE_NAME = "enforces-negative-arbitrary-values";
 
 // Message IDs don't need to be prefixed, I just find it easier to keep track of them this way

--- a/src/rules/enforces-shorthand.ts
+++ b/src/rules/enforces-shorthand.ts
@@ -28,8 +28,6 @@ import {
 } from "../utils/rule";
 import { isValidClassNameWorker } from "../utils/tailwindcss-api";
 
-export { ESLintUtils } from "@typescript-eslint/utils";
-
 export const RULE_NAME = "enforces-shorthand";
 
 // Message IDs don't need to be prefixed, I just find it easier to keep track of them this way

--- a/src/rules/important-modifier-suffix.spec.ts
+++ b/src/rules/important-modifier-suffix.spec.ts
@@ -46,11 +46,15 @@ ruleTester.run(RULE_NAME, importantModifierSuffix, {
         code: `ctl('dark:!m-[10px]')`,
         importantPrefixedClass: "dark:!m-[10px]",
         importantSuffixedClass: "dark:m-[10px]!",
+        output: `ctl('dark:m-[10px]!')`,
       },
-    ].map(({ code, importantPrefixedClass, importantSuffixedClass }) => ({
-      code: code,
-      errors: [generateError(importantPrefixedClass, importantSuffixedClass)],
-    })),
+    ].map(
+      ({ code, importantPrefixedClass, importantSuffixedClass, output }) => ({
+        code: code,
+        output,
+        errors: [generateError(importantPrefixedClass, importantSuffixedClass)],
+      }),
+    ),
     ...[
       {
         code: `
@@ -61,9 +65,16 @@ ruleTester.run(RULE_NAME, importantModifierSuffix, {
         \`)`,
         invalidClasses: ["lg:!block", "!-m-2"],
         suffixedClasses: ["lg:block!", "-m-2!"],
+        output: `
+        ctl(\`
+          lg:block!
+          dark:bg-white
+          -m-2!
+        \`)`,
       },
-    ].map(({ code, invalidClasses, suffixedClasses }) => ({
+    ].map(({ code, invalidClasses, suffixedClasses, output }) => ({
       code: code,
+      output,
       errors: invalidClasses.map((importantPrefixedClass, index) =>
         generateError(importantPrefixedClass, suffixedClasses[index]),
       ),

--- a/src/rules/important-modifier-suffix.spec.ts
+++ b/src/rules/important-modifier-suffix.spec.ts
@@ -1,0 +1,72 @@
+import * as Parser from "@typescript-eslint/parser";
+import { RuleTester, TestCaseError } from "@typescript-eslint/rule-tester";
+
+import { generalSettings } from "../utils/parser/test-helpers";
+import {
+  importantModifierSuffix,
+  type MessageIds,
+  RULE_NAME,
+} from "./important-modifier-suffix";
+
+const generateError = (
+  className: string,
+  patchedClassName: string,
+): TestCaseError<MessageIds> => {
+  return {
+    messageId: "issue:important-modifier-prefix",
+    data: { className, patchedClassName },
+  };
+};
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: Parser,
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+  settings: {
+    tailwindcss: {
+      ...generalSettings,
+    },
+  },
+});
+
+ruleTester.run(RULE_NAME, importantModifierSuffix, {
+  valid:
+    // JSX
+    ["ctl('m-0')", "ctl('m-0! lg:p-5!')"].map((testedJsxCode) => ({
+      code: testedJsxCode,
+    })),
+  invalid: [
+    ...[
+      {
+        code: `ctl('dark:!m-[10px]')`,
+        importantPrefixedClass: "dark:!m-[10px]",
+        importantSuffixedClass: "dark:m-[10px]!",
+      },
+    ].map(({ code, importantPrefixedClass, importantSuffixedClass }) => ({
+      code: code,
+      errors: [generateError(importantPrefixedClass, importantSuffixedClass)],
+    })),
+    ...[
+      {
+        code: `
+        ctl(\`
+          lg:!block
+          dark:bg-white
+          !-m-2
+        \`)`,
+        invalidClasses: ["lg:!block", "!-m-2"],
+        suffixedClasses: ["lg:block!", "-m-2!"],
+      },
+    ].map(({ code, invalidClasses, suffixedClasses }) => ({
+      code: code,
+      errors: invalidClasses.map((importantPrefixedClass, index) =>
+        generateError(importantPrefixedClass, suffixedClasses[index]),
+      ),
+    })),
+  ],
+});

--- a/src/rules/important-modifier-suffix.spec.ts
+++ b/src/rules/important-modifier-suffix.spec.ts
@@ -65,12 +65,20 @@ ruleTester.run(RULE_NAME, importantModifierSuffix, {
         \`)`,
         invalidClasses: ["lg:!block", "!-m-2"],
         suffixedClasses: ["lg:block!", "-m-2!"],
-        output: `
+        output: [
+          `
+        ctl(\`
+          lg:block!
+          dark:bg-white
+          !-m-2
+        \`)`,
+          `
         ctl(\`
           lg:block!
           dark:bg-white
           -m-2!
         \`)`,
+        ],
       },
     ].map(({ code, invalidClasses, suffixedClasses, output }) => ({
       code: code,

--- a/src/rules/important-modifier-suffix.ts
+++ b/src/rules/important-modifier-suffix.ts
@@ -4,15 +4,20 @@
  * @author François Massart
  */
 
+import { TSESTree } from "@typescript-eslint/utils";
 import { RuleCreator } from "@typescript-eslint/utils/eslint-utils";
 import { RuleContext as TSESLintRuleContext } from "@typescript-eslint/utils/ts-eslint";
 
 import urlCreator from "../url-creator";
+import { joiner } from "../utils/joiner";
 import {
   parsePluginSettings,
   PluginSettings,
 } from "../utils/parse-plugin-settings";
-import { getBaseClassname } from "../utils/parser/classname";
+import {
+  getBaseClassname,
+  getModifiersPrefix,
+} from "../utils/parser/classname";
 import {
   dissectAtomicNode,
   generateLocForClassname,
@@ -57,14 +62,24 @@ const importantPrefixClassnames = (
   const totalLiterals = literals.length;
   for (let index = 0; index < totalLiterals; index++) {
     const node = literals[index];
-    const { originalClassNamesValue } = dissectAtomicNode(node, genericContext);
+    const { originalClassNamesValue, start, end, prefix, suffix } =
+      dissectAtomicNode(node, genericContext);
 
     // Early escape if the value is falsy or doesn't contain any brackets (no arbitrary value possible)
     if (!originalClassNamesValue || !originalClassNamesValue.includes("!"))
       continue;
 
-    const { classNames } = getClassnamesFromValue(originalClassNamesValue);
+    // 1. Gather invalid classes in the node
+    const invalidClassesInNode: Array<{
+      classname: string;
+      patched: string;
+      type: string;
+    }> = [];
+
+    const { classNames, whitespaces, headSpace, tailSpace } =
+      getClassnamesFromValue(originalClassNamesValue);
     const classNamesLength = classNames.length;
+    const patchedClassNames = [...classNames];
 
     for (let index = 0; index < classNamesLength; index++) {
       const targetClassName = classNames[index];
@@ -76,26 +91,56 @@ const importantPrefixClassnames = (
       if (checkedClasses.has(targetClassName)) continue;
       checkedClasses.add(targetClassName);
 
+      const modifiers = getModifiersPrefix(targetClassName);
       const baseClass = getBaseClassname(targetClassName);
 
       if (!baseClass.startsWith("!")) {
         continue;
       }
 
+      const patched = `${modifiers}${baseClass.slice(1)}!`;
+      invalidClassesInNode.push({
+        classname: targetClassName,
+        patched: patched,
+        type: node.type,
+      });
+      patchedClassNames[index] = patched;
+    }
+    // All classes are valid, skip to the next node
+    if (invalidClassesInNode.length === 0) continue;
+
+    // 2. Emit reports with a surgical fix (one class targeted)
+    for (const invalidClass of invalidClassesInNode) {
+      const fixable = invalidClass.type !== TSESTree.AST_NODE_TYPES.Identifier;
       const patchedLoc = generateLocForClassname(
         node,
-        targetClassName,
+        invalidClass.classname,
         originalClassNamesValue,
         genericContext,
       );
 
+      // Generate the fix exclusive to THIS iteration of the class
+      let patchedValue: string;
+      if (fixable) {
+        patchedValue = joiner({
+          classNames: patchedClassNames,
+          whitespaces,
+          headSpace,
+          tailSpace,
+        });
+
+        patchedValue = prefix + patchedValue + suffix;
+      }
       context.report({
         loc: patchedLoc,
         messageId: "issue:important-modifier-prefix",
         data: {
-          className: targetClassName,
-          patchedClassName: targetClassName,
+          className: invalidClass.classname,
+          patchedClassName: invalidClass.patched,
         },
+        fix: fixable
+          ? (fixer) => fixer.replaceTextRange([start, end], patchedValue)
+          : undefined,
       });
     }
   }
@@ -108,11 +153,11 @@ export const importantModifierSuffix = createRule<Options, MessageIds>({
       description:
         "In v4 you should place the `!` at the very end of the class name.",
     },
-    hasSuggestions: false,
     messages: {
       "issue:important-modifier-prefix":
-        "Class '{{className}}' should place '!' at the very end ('{{className}}')",
+        "Class '{{className}}' should place '!' at the very end ('{{patchedClassName}}')",
     },
+    fixable: "code",
     // Schema is also parsed by `eslint-doc-generator`
     schema: [
       {

--- a/src/rules/important-modifier-suffix.ts
+++ b/src/rules/important-modifier-suffix.ts
@@ -30,8 +30,6 @@ import {
   createTemplateVisitors,
 } from "../utils/rule";
 
-export { ESLintUtils } from "@typescript-eslint/utils";
-
 export const RULE_NAME = "important-modifier-suffix";
 
 // Message IDs don't need to be prefixed, I just find it easier to keep track of them this way
@@ -98,7 +96,6 @@ const importantPrefixClassnames = (
 
     const fixable = node.type !== TSESTree.AST_NODE_TYPES.Identifier;
 
-    // Emit reports
     for (const invalidClass of invalidClassesInNode) {
       const patchedLoc = generateLocForClassname(
         node,

--- a/src/rules/important-modifier-suffix.ts
+++ b/src/rules/important-modifier-suffix.ts
@@ -56,62 +56,50 @@ const importantPrefixClassnames = (
 ) => {
   const genericContext = context as unknown as GenericRuleContext;
 
-  // Session cache to avoid re-testing identical classes within the same node/file
-  const checkedClasses = new Set<string>();
-
   const totalLiterals = literals.length;
   for (let index = 0; index < totalLiterals; index++) {
     const node = literals[index];
     const { originalClassNamesValue, start, end, prefix, suffix } =
       dissectAtomicNode(node, genericContext);
 
-    // Early escape if the value is falsy or doesn't contain any brackets (no arbitrary value possible)
-    if (!originalClassNamesValue || !originalClassNamesValue.includes("!"))
+    // Early escape if the value is falsy or doesn't contain "!"
+    if (!originalClassNamesValue || !originalClassNamesValue.includes("!")) {
       continue;
-
-    // 1. Gather invalid classes in the node
-    const invalidClassesInNode: Array<{
-      classname: string;
-      patched: string;
-      type: string;
-    }> = [];
+    }
 
     const { classNames, whitespaces, headSpace, tailSpace } =
       getClassnamesFromValue(originalClassNamesValue);
+
+    const invalidClassesInNode: Array<{
+      index: number; // Keep track of its position for surgical fixing
+      classname: string;
+      patched: string;
+    }> = [];
+
     const classNamesLength = classNames.length;
-    const patchedClassNames = [...classNames];
+    for (let index_ = 0; index_ < classNamesLength; index_++) {
+      const targetClassName = classNames[index_];
 
-    for (let index = 0; index < classNamesLength; index++) {
-      const targetClassName = classNames[index];
-
-      // Individual early escape for classnames that don't contain brackets
       if (!targetClassName.includes("!")) continue;
 
-      // Local cache
-      if (checkedClasses.has(targetClassName)) continue;
-      checkedClasses.add(targetClassName);
-
-      const modifiers = getModifiersPrefix(targetClassName);
       const baseClass = getBaseClassname(targetClassName);
+      if (!baseClass.startsWith("!")) continue;
 
-      if (!baseClass.startsWith("!")) {
-        continue;
-      }
+      const patched = `${getModifiersPrefix(targetClassName)}${baseClass.slice(1)}!`;
 
-      const patched = `${modifiers}${baseClass.slice(1)}!`;
       invalidClassesInNode.push({
+        index: index_,
         classname: targetClassName,
-        patched: patched,
-        type: node.type,
+        patched,
       });
-      patchedClassNames[index] = patched;
     }
-    // All classes are valid, skip to the next node
+
     if (invalidClassesInNode.length === 0) continue;
 
-    // 2. Emit reports with a surgical fix (one class targeted)
+    const fixable = node.type !== TSESTree.AST_NODE_TYPES.Identifier;
+
+    // Emit reports
     for (const invalidClass of invalidClassesInNode) {
-      const fixable = invalidClass.type !== TSESTree.AST_NODE_TYPES.Identifier;
       const patchedLoc = generateLocForClassname(
         node,
         invalidClass.classname,
@@ -119,18 +107,6 @@ const importantPrefixClassnames = (
         genericContext,
       );
 
-      // Generate the fix exclusive to THIS iteration of the class
-      let patchedValue: string;
-      if (fixable) {
-        patchedValue = joiner({
-          classNames: patchedClassNames,
-          whitespaces,
-          headSpace,
-          tailSpace,
-        });
-
-        patchedValue = prefix + patchedValue + suffix;
-      }
       context.report({
         loc: patchedLoc,
         messageId: "issue:important-modifier-prefix",
@@ -139,7 +115,23 @@ const importantPrefixClassnames = (
           patchedClassName: invalidClass.patched,
         },
         fix: fixable
-          ? (fixer) => fixer.replaceTextRange([start, end], patchedValue)
+          ? (fixer) => {
+              // Create a fresh clone of the classNames array for THIS specific fix
+              const localPatchedClassNames = [...classNames];
+              localPatchedClassNames[invalidClass.index] = invalidClass.patched;
+
+              const patchedValue =
+                prefix +
+                joiner({
+                  classNames: localPatchedClassNames,
+                  whitespaces,
+                  headSpace,
+                  tailSpace,
+                }) +
+                suffix;
+
+              return fixer.replaceTextRange([start, end], patchedValue);
+            }
           : undefined,
       });
     }

--- a/src/rules/important-modifier-suffix.ts
+++ b/src/rules/important-modifier-suffix.ts
@@ -1,0 +1,158 @@
+/**
+ * @fileoverview In v3 you could mark a utility as important by placing an `!` at the beginning of the utility name (but after any variants).
+ * In v4 you should place the `!` at the very end of the class name instead. The old way is still supported for compatibility but is deprecated.
+ * @author François Massart
+ */
+
+import { RuleCreator } from "@typescript-eslint/utils/eslint-utils";
+import { RuleContext as TSESLintRuleContext } from "@typescript-eslint/utils/ts-eslint";
+
+import urlCreator from "../url-creator";
+import {
+  parsePluginSettings,
+  PluginSettings,
+} from "../utils/parse-plugin-settings";
+import { getBaseClassname } from "../utils/parser/classname";
+import {
+  dissectAtomicNode,
+  generateLocForClassname,
+  getClassnamesFromValue,
+} from "../utils/parser/node";
+import { defineVisitors, GenericRuleContext } from "../utils/parser/visitors";
+import {
+  AtomicNode,
+  createScriptVisitors,
+  createTemplateVisitors,
+} from "../utils/rule";
+
+export { ESLintUtils } from "@typescript-eslint/utils";
+
+export const RULE_NAME = "important-modifier-suffix";
+
+// Message IDs don't need to be prefixed, I just find it easier to keep track of them this way
+export type MessageIds = "issue:important-modifier-prefix";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export type RuleOptions = {};
+
+type Options = [RuleOptions];
+
+type RuleContext = TSESLintRuleContext<MessageIds, Options>;
+
+// The Rule creator returns a function that is used to create a well-typed ESLint rule
+// The parameter passed into RuleCreator is a URL generator function.
+export const createRule = RuleCreator(urlCreator);
+
+const importantPrefixClassnames = (
+  context: RuleContext,
+  settings: PluginSettings,
+  options: RuleOptions,
+  literals: Array<AtomicNode>,
+) => {
+  const genericContext = context as unknown as GenericRuleContext;
+
+  // Session cache to avoid re-testing identical classes within the same node/file
+  const checkedClasses = new Set<string>();
+
+  const totalLiterals = literals.length;
+  for (let index = 0; index < totalLiterals; index++) {
+    const node = literals[index];
+    const { originalClassNamesValue } = dissectAtomicNode(node, genericContext);
+
+    // Early escape if the value is falsy or doesn't contain any brackets (no arbitrary value possible)
+    if (!originalClassNamesValue || !originalClassNamesValue.includes("!"))
+      continue;
+
+    const { classNames } = getClassnamesFromValue(originalClassNamesValue);
+    const classNamesLength = classNames.length;
+
+    for (let index = 0; index < classNamesLength; index++) {
+      const targetClassName = classNames[index];
+
+      // Individual early escape for classnames that don't contain brackets
+      if (!targetClassName.includes("!")) continue;
+
+      // Local cache
+      if (checkedClasses.has(targetClassName)) continue;
+      checkedClasses.add(targetClassName);
+
+      const baseClass = getBaseClassname(targetClassName);
+
+      if (!baseClass.startsWith("!")) {
+        continue;
+      }
+
+      const patchedLoc = generateLocForClassname(
+        node,
+        targetClassName,
+        originalClassNamesValue,
+        genericContext,
+      );
+
+      context.report({
+        loc: patchedLoc,
+        messageId: "issue:important-modifier-prefix",
+        data: {
+          className: targetClassName,
+          patchedClassName: targetClassName,
+        },
+      });
+    }
+  }
+};
+
+export const importantModifierSuffix = createRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    docs: {
+      description:
+        "In v4 you should place the `!` at the very end of the class name.",
+    },
+    hasSuggestions: false,
+    messages: {
+      "issue:important-modifier-prefix":
+        "Class '{{className}}' should place '!' at the very end ('{{className}}')",
+    },
+    // Schema is also parsed by `eslint-doc-generator`
+    schema: [
+      {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [{}],
+    type: "problem",
+  },
+  /**
+   * About `defaultOptions`:
+   * - `defaultOptions` is not parsed to generate the documentation
+   * - `defaultOptions` is used when options are NOT provided in the rules configuration
+   * - If some configuration is provided as the second argument, `defaultOptions` is ignored completely (not merged)
+   * - In other words, the `defaultOptions` is only used when the rule is used WITHOUT any configuration
+   */
+
+  defaultOptions: [{}],
+  create: (context, options) => {
+    // Merged settings
+    const settings = parsePluginSettings(context.settings);
+
+    return defineVisitors(
+      context as unknown as Readonly<GenericRuleContext>,
+      // Template visitor is only used within Vue SFC files (inside <template> section).
+      createTemplateVisitors(
+        context,
+        settings,
+        options,
+        importantPrefixClassnames,
+      ),
+      // Script visitor is used within both JSX and Vue SFC files (inside <script> section).
+      createScriptVisitors(
+        context,
+        settings,
+        options,
+        importantPrefixClassnames,
+      ),
+    );
+  },
+});

--- a/src/rules/no-arbitrary-value.ts
+++ b/src/rules/no-arbitrary-value.ts
@@ -24,8 +24,6 @@ import {
   createTemplateVisitors,
 } from "../utils/rule";
 
-export { ESLintUtils } from "@typescript-eslint/utils";
-
 export const RULE_NAME = "no-arbitrary-value";
 
 // Message IDs don't need to be prefixed, I just find it easier to keep track of them this way

--- a/src/rules/no-contradicting-classname.ts
+++ b/src/rules/no-contradicting-classname.ts
@@ -33,8 +33,6 @@ import {
   flattenNestingWorker,
 } from "../utils/tailwindcss-api";
 
-export { ESLintUtils } from "@typescript-eslint/utils";
-
 export const RULE_NAME = "no-contradicting-classname";
 
 // Message IDs don't need to be prefixed, I just find it easier to keep track of them this way

--- a/src/rules/no-custom-classname.ts
+++ b/src/rules/no-custom-classname.ts
@@ -27,8 +27,6 @@ import {
 } from "../utils/rule";
 import { isValidClassNameWorker } from "../utils/tailwindcss-api";
 
-export { ESLintUtils } from "@typescript-eslint/utils";
-
 export const RULE_NAME = "no-custom-classname";
 
 // Message IDs don't need to be prefixed, I just find it easier to keep track of them this way

--- a/src/rules/no-unnecessary-arbitrary-value.ts
+++ b/src/rules/no-unnecessary-arbitrary-value.ts
@@ -43,8 +43,6 @@ import { loadThemeWorker } from "../utils/tailwindcss-api";
 import { toTailwindArbitrary } from "../utils/to-tailwind-arbitrary";
 import { convertStringValueToPx } from "../utils/units";
 
-export { ESLintUtils } from "@typescript-eslint/utils";
-
 export const RULE_NAME = "no-unnecessary-arbitrary-value";
 
 // Message IDs don't need to be prefixed, I just find it easier to keep track of them this way


### PR DESCRIPTION
# 🚀 Features

New rule `important-modifier-suffix`: Makes sure the `!` important modifier is at the end of the class names. The former `!` location (between the modifiers and the class name hes been deprecated).