### PR TITLE
svelte-eslint-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "docs:init": "eslint-doc-generator --init-rule-docs",
     "docs:update": "eslint-doc-generator",
     "test": "vitest",
-    "wip": "vitest src/rules/classnames-order.wip.spec.ts",
     "tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "docs:init": "eslint-doc-generator --init-rule-docs",
     "docs:update": "eslint-doc-generator",
     "test": "vitest",
-    "wip": "vitest src/rules/no-unnecessary-arbitrary-value.wip.spec.ts",
+    "wip": "vitest src/rules/classnames-order.wip.spec.ts",
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
@@ -69,6 +69,7 @@
     "@eslint/js": "^9.16.0",
     "@tailwindcss/typography": "^0.5.16",
     "@types/eslint": "^8.56.10",
+    "@types/estree": "^1.0.9",
     "@typescript-eslint/parser": "^8.37.0",
     "@typescript-eslint/rule-tester": "^8.37.0",
     "daisyui": "^5.5.23",
@@ -80,6 +81,8 @@
     "eslint-plugin-unicorn": "^56.0.1",
     "globals": "^15.13.0",
     "prettier": "^3.5.3",
+    "svelte": "^5.56.4",
+    "svelte-eslint-parser": "^1.8.0",
     "tailwindcss": "^4.3.1",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwindcss",
-  "version": "4.2.0",
+  "version": "4.3.0-svelte.beta.0",
   "publishConfig": {
     "publish-branch": "v4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@types/eslint':
         specifier: ^8.56.10
         version: 8.56.12
+      '@types/estree':
+        specifier: ^1.0.9
+        version: 1.0.9
       '@typescript-eslint/parser':
         specifier: ^8.37.0
         version: 8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
@@ -69,6 +72,12 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.6.2
+      svelte:
+        specifier: ^5.56.4
+        version: 5.56.4(@typescript-eslint/types@8.42.0)
+      svelte-eslint-parser:
+        specifier: ^1.8.0
+        version: 1.8.0(svelte@5.56.4(@typescript-eslint/types@8.42.0))
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -459,8 +468,21 @@ packages:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -646,6 +668,11 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sveltejs/acorn-typescript@1.0.11':
+    resolution: {integrity: sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@tailwindcss/typography@0.5.16':
     resolution: {integrity: sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==}
     peerDependencies:
@@ -656,6 +683,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -668,6 +698,9 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@8.42.0':
     resolution: {integrity: sha512-Aq2dPqsQkxHOLfb2OPv43RnIvfj05nw8v/6n3B2NABIPpHnjQnaLo9QGMTvml+tv4korl/Cjfrb/BYhoL8UUTQ==}
@@ -780,6 +813,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -820,6 +857,10 @@ packages:
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
   balanced-match@1.0.2:
@@ -897,6 +938,10 @@ packages:
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1053,6 +1098,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -1236,6 +1284,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1243,6 +1294,14 @@ packages:
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
+
+  esrap@2.2.13:
+    resolution: {integrity: sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -1532,6 +1591,9 @@ packages:
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1659,6 +1721,9 @@ packages:
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -2060,6 +2125,12 @@ packages:
     peerDependencies:
       postcss: ^8.4.32
 
+  postcss-scss@4.0.9:
+    resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.29
+
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
@@ -2318,6 +2389,19 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svelte-eslint-parser@1.8.0:
+    resolution: {integrity: sha512-mikR1qwIVy3t5WthUoAXkMwxkXvabZP9FJgdx35Ei7EbGWmctva1Pih16Koeor/bdNNq8NXHlwKGS6NkYTawLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0, pnpm: 10.34.1}
+    peerDependencies:
+      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
+  svelte@5.56.4:
+    resolution: {integrity: sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==}
+    engines: {node: '>=18'}
+
   svgo@4.0.0:
     resolution: {integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==}
     engines: {node: '>=16'}
@@ -2555,6 +2639,9 @@ packages:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
 
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
 snapshots:
 
   '@angular-eslint/bundled-angular-compiler@20.2.0': {}
@@ -2780,7 +2867,24 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.8
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2839,7 +2943,7 @@ snapshots:
 
   '@rollup/pluginutils@5.2.0(rollup@4.50.0)':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
@@ -2912,6 +3016,10 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@sveltejs/acorn-typescript@1.0.11(acorn@8.15.0)':
+    dependencies:
+      acorn: 8.15.0
+
   '@tailwindcss/typography@0.5.16(tailwindcss@4.3.1)':
     dependencies:
       lodash.castarray: 4.4.0
@@ -2922,10 +3030,12 @@ snapshots:
 
   '@types/eslint@8.56.12':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -2934,6 +3044,8 @@ snapshots:
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/resolve@1.20.2': {}
+
+  '@types/trusted-types@2.0.7': {}
 
   '@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
@@ -3103,6 +3215,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.1: {}
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -3170,6 +3284,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axobject-query@4.1.0: {}
 
   balanced-match@1.0.2: {}
 
@@ -3257,6 +3373,8 @@ snapshots:
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3424,6 +3542,8 @@ snapshots:
       object-keys: 1.1.1
 
   defu@6.1.4: {}
+
+  devalue@5.8.1: {}
 
   diff-sequences@29.6.3: {}
 
@@ -3743,7 +3863,7 @@ snapshots:
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
@@ -3772,6 +3892,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@10.4.0:
     dependencies:
       acorn: 8.15.0
@@ -3781,6 +3903,12 @@ snapshots:
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap@2.2.13(@typescript-eslint/types@8.42.0):
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optionalDependencies:
+      '@typescript-eslint/types': 8.42.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -3792,7 +3920,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -4063,7 +4191,11 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
+
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
 
   is-regex@1.2.1:
     dependencies:
@@ -4176,6 +4308,8 @@ snapshots:
       mlly: 1.8.0
       pkg-types: 2.3.0
       quansync: 0.2.11
+
+  locate-character@3.0.0: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -4552,6 +4686,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  postcss-scss@4.0.9(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-selector-parser@6.0.10:
     dependencies:
       cssesc: 3.0.0
@@ -4853,6 +4991,39 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svelte-eslint-parser@1.8.0(svelte@5.56.4(@typescript-eslint/types@8.42.0)):
+    dependencies:
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      postcss: 8.5.6
+      postcss-scss: 4.0.9(postcss@8.5.6)
+      postcss-selector-parser: 7.1.0
+      semver: 7.7.2
+    optionalDependencies:
+      svelte: 5.56.4(@typescript-eslint/types@8.42.0)
+
+  svelte@5.56.4(@typescript-eslint/types@8.42.0):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.11(acorn@8.15.0)
+      '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
+      acorn: 8.15.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.8.1
+      esm-env: 1.2.2
+      esrap: 2.2.13(@typescript-eslint/types@8.42.0)
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.18
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
 
   svgo@4.0.0:
     dependencies:
@@ -5156,3 +5327,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.1: {}
+
+  zimmerframe@1.1.4: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,14 @@ const configBase: FlatConfig.Config = {
   settings: {
     tailwindcss: {},
   },
-  files: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+  files: [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.svelte",
+    "**/*.vue",
+  ],
   languageOptions: {
     parserOptions: {
       ecmaVersion: "latest",

--- a/src/rules/classnames-order.spec.ts
+++ b/src/rules/classnames-order.spec.ts
@@ -7,6 +7,7 @@ import {
   generalSettings,
   prefixedSettings,
   withAngularParser,
+  withSvelteParser,
   withTypographySettings,
   withVueParser,
   xsBreakpointSettings,
@@ -68,6 +69,12 @@ const getExpectedErrors = (
   }));
 };
 
+const defaultSettings = {
+  tailwindcss: {
+    ...generalSettings,
+  },
+};
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser: Parser,
@@ -77,11 +84,7 @@ const ruleTester = new RuleTester({
       },
     },
   },
-  settings: {
-    tailwindcss: {
-      ...generalSettings,
-    },
-  },
+  settings: defaultSettings,
 });
 
 ruleTester.run(RULE_NAME, classnamesOrder, {
@@ -130,6 +133,40 @@ ruleTester.run(RULE_NAME, classnamesOrder, {
     ].map((testedJsxCode) => ({
       code: testedJsxCode,
     })),
+    // Svelte
+    ...[
+      `
+        <script>
+          const vertical = true;
+          const styles = tw\`absolute block\`;
+          const ctl = ctl('absolute block');
+        </script>
+        <section class="m-0 p-6">Simple</section>
+        <section class={vertical ? 'flex-col' : 'flex-row'}>Primitive values</section>
+      `,
+      // https://svelte.dev/docs/svelte/class#Attributes-Objects-and-arrays
+      `
+      <script>
+        let { shown } = true;
+      </script>
+      <div class={{ "absolute block": shown, "invisible size-0": !shown }}>...</div>
+      `,
+      // https://svelte.dev/docs/svelte/class#Attributes-Objects-and-arrays
+      `
+      <script>
+        const faded = true;
+        const large = true;
+      </script>
+      <div class={[faded && 'opacity-50 saturate-0', large && 'scale-200']}>...</div>
+      `,
+      // https://svelte.dev/docs/svelte/class#Attributes-Objects-and-arrays
+      `
+      <div class={['absolute block', props.class]}>...</div>
+      `,
+    ].map((testedSvelteCode) => ({
+      code: testedSvelteCode,
+      languageOptions: withSvelteParser,
+    })),
     // Vue SFC
     ...[
       `<template><h1 class="unkown relative">vAttributeVisitor static</h1></template>`,
@@ -166,10 +203,6 @@ ruleTester.run(RULE_NAME, classnamesOrder, {
       settings: { tailwindcss: { ...generalSettings, attributes: [] } },
       languageOptions: withVueParser,
     })),
-    {
-      code: `<div className={'unknown tw:relative'}>Valid with custom prefix</div>`,
-      settings: { tailwindcss: { ...prefixedSettings } },
-    },
     // JSX + Custom functions/tag
     ...[
       `<div className={ctl('flex unknown relative')}>Ignored CallExpression inside a prop</div>`,
@@ -179,14 +212,20 @@ ruleTester.run(RULE_NAME, classnamesOrder, {
       const myTag = {
         subTag: (strings) => {
           return \`$\{strings}\`;
-        }
-      };
-      const classes = myTag.subTag\`unknown relative\`;
-      `,
+          }
+          };
+          const classes = myTag.subTag\`unknown relative\`;
+          `,
     ].map((testedCode) => ({
       code: testedCode,
       settings: { tailwindcss: { ...generalSettings, functions: ["myTag"] } },
     })),
+    // JSX + `tw:` prefix
+    {
+      code: `<div className={'unknown tw:relative'}>Valid with custom prefix</div>`,
+      settings: { tailwindcss: { ...prefixedSettings } },
+    },
+    // JSX + extra/custom `xs` breakpoint
     {
       code: `<div class="xs:text-xl sm:text-2xl md:text-3xl">Issue 337</div>`,
       settings: { tailwindcss: { ...xsBreakpointSettings } },
@@ -194,6 +233,72 @@ ruleTester.run(RULE_NAME, classnamesOrder, {
   ],
   invalid: (
     [
+      // Svelte
+      {
+        code: `
+        <script>
+          const vertical = true;
+          const styles = tw\`block absolute\`;
+          const ctl = ctl('absolute block');
+        </script>
+        <section class="m-0 p-6">Simple</section>
+        <section class={vertical ? 'flex-col' : 'flex-row'}>Primitive values</section>
+        `,
+        output: `
+        <script>
+          const vertical = true;
+          const styles = tw\`absolute block\`;
+          const ctl = ctl('absolute block');
+        </script>
+        <section class="m-0 p-6">Simple</section>
+        <section class={vertical ? 'flex-col' : 'flex-row'}>Primitive values</section>
+        `,
+        errors: errors,
+        languageOptions: withSvelteParser,
+      },
+      // https://svelte.dev/docs/svelte/class#Attributes-Objects-and-arrays
+      {
+        code: `
+        <script>
+          let { shown } = true;
+        </script>
+        <div class={{ "block absolute": shown, "size-0 invisible": !shown }}>...</div>
+        `,
+        output: `
+        <script>
+          let { shown } = true;
+        </script>
+        <div class={{ "absolute block": shown, "invisible size-0": !shown }}>...</div>
+        `,
+        errors: errors,
+        languageOptions: withSvelteParser,
+      },
+      // https://svelte.dev/docs/svelte/class#Attributes-Objects-and-arrays
+      {
+        code: `
+        <script>
+          const faded = true;
+          const large = true;
+        </script>
+        <div class={[faded && 'saturate-0 opacity-50', large && 'scale-200']}>...</div>
+        `,
+        output: `
+        <script>
+          const faded = true;
+          const large = true;
+        </script>
+        <div class={[faded && 'opacity-50 saturate-0', large && 'scale-200']}>...</div>
+        `,
+        errors: errors,
+        languageOptions: withSvelteParser,
+      },
+      // https://svelte.dev/docs/svelte/class#Attributes-Objects-and-arrays
+      {
+        code: `<div class={['block absolute', props.class]}>...</div>`,
+        output: `<div class={['absolute block', props.class]}>...</div>`,
+        errors: errors,
+        languageOptions: withSvelteParser,
+      },
       {
         /* prettier-ignore */
         code:   `<h1 class="text-gray-700 shadow-md p-3 border-gray-300 ml-4 h-24 flex border-2">https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#how-classes-are-sorted</h1>`,
@@ -248,33 +353,33 @@ ruleTester.run(RULE_NAME, classnamesOrder, {
         ],
         [
           `
-      ctl(\`
-        invalid
-        sm:w-6
-        container
-        invalid
-        flex
-        container
-        w-12
-        flex
-        container
-        lg:w-4
-        lg:w-4
-      \`);`,
+          ctl(\`
+            invalid
+            sm:w-6
+            container
+            invalid
+            flex
+            container
+            w-12
+            flex
+            container
+            lg:w-4
+            lg:w-4
+          \`);`,
           `
-      ctl(\`
-        invalid
-        invalid
-        container
-        container
-        container
-        flex
-        flex
-        w-12
-        sm:w-6
-        lg:w-4
-        lg:w-4
-      \`);`,
+          ctl(\`
+            invalid
+            invalid
+            container
+            container
+            container
+            flex
+            flex
+            w-12
+            sm:w-6
+            lg:w-4
+            lg:w-4
+          \`);`,
         ],
         [
           `cva({ primary: ["bottom-0 w-full h-[70px] flex flex-col"], })`,
@@ -369,27 +474,27 @@ ruleTester.run(RULE_NAME, classnamesOrder, {
         ],
         [
           `
-      <template>
-        <div v-bind="data" :class="[
-          'py-1.5 font-semibold transition',
-          {
-            'text-white': variant === 'white',
-            'text-blue-500 hover:text-blue-400 border-blue-500': variant === 'primary',
-            'underline decoration-2 underline-offset-[10px]': active
-          }
-        ]" />
-      </template>`,
+          <template>
+            <div v-bind="data" :class="[
+              'py-1.5 font-semibold transition',
+              {
+                'text-white': variant === 'white',
+                'text-blue-500 hover:text-blue-400 border-blue-500': variant === 'primary',
+                'underline decoration-2 underline-offset-[10px]': active
+              }
+            ]" />
+          </template>`,
           `
-      <template>
-        <div v-bind="data" :class="[
-          'py-1.5 font-semibold transition',
-          {
-            'text-white': variant === 'white',
-            'border-blue-500 text-blue-500 hover:text-blue-400': variant === 'primary',
-            'underline decoration-2 underline-offset-[10px]': active
-          }
-        ]" />
-      </template>`,
+          <template>
+            <div v-bind="data" :class="[
+              'py-1.5 font-semibold transition',
+              {
+                'text-white': variant === 'white',
+                'border-blue-500 text-blue-500 hover:text-blue-400': variant === 'primary',
+                'underline decoration-2 underline-offset-[10px]': active
+              }
+            ]" />
+          </template>`,
         ],
       ].map(([input, result]) => ({
         code: input,
@@ -406,93 +511,95 @@ ruleTester.run(RULE_NAME, classnamesOrder, {
       },
       {
         code: `
-      const buttonClasses = ctl(\`
-        \${fullWidth ? "w-12" : "w-6"}
-        flex
-        container
-        \${fullWidth ? "sm:w-7" : "sm:w-4"}
-        lg:py-4
-        sm:py-6
-        \${hasError && "bg-red"}
-      \`);`,
+        const buttonClasses = ctl(\`
+          \${fullWidth ? "w-12" : "w-6"}
+          flex
+          container
+          \${fullWidth ? "sm:w-7" : "sm:w-4"}
+          lg:py-4
+          sm:py-6
+          \${hasError && "bg-red"}
+        \`);`,
         output: `
-      const buttonClasses = ctl(\`
-        \${fullWidth ? "w-12" : "w-6"}
-        container
-        flex
-        \${fullWidth ? "sm:w-7" : "sm:w-4"}
-        sm:py-6
-        lg:py-4
-        \${hasError && "bg-red"}
-      \`);`,
+        const buttonClasses = ctl(\`
+          \${fullWidth ? "w-12" : "w-6"}
+          container
+          flex
+          \${fullWidth ? "sm:w-7" : "sm:w-4"}
+          sm:py-6
+          lg:py-4
+          \${hasError && "bg-red"}
+        \`);`,
         errors: [error, error],
       },
+      /*/
       {
         code: `
-      ctl(\`
-        px-2
-        flex
-        \${
-          !isDisabled &&
-          \`
-            top-0
-            flex
-            border-0
-          \`
-        }
-        \${
-          isDisabled &&
-          \`
-            border-0
-            mx-0
-          \`
-        }
-      \`)
-      `,
+        ctl(\`
+          px-2
+          flex
+          \${
+            !isDisabled &&
+            \`
+              top-0
+              flex
+              border-0
+            \`
+          }
+          \${
+            isDisabled &&
+            \`
+              border-0
+              mx-0
+            \`
+          }
+        \`)
+        `,
         output: `
-      ctl(\`
-        flex
-        px-2
-        \${
-          !isDisabled &&
-          \`
-            top-0
-            flex
-            border-0
-          \`
-        }
-        \${
-          isDisabled &&
-          \`
-            mx-0
-            border-0
-          \`
-        }
-      \`)
+        ctl(\`
+          flex
+          px-2
+          \${
+            !isDisabled &&
+            \`
+              top-0
+              flex
+              border-0
+            \`
+          }
+          \${
+            isDisabled &&
+            \`
+              mx-0
+              border-0
+            \`
+          }
+        \`)
       `,
         errors: [error, error],
       },
+      //*/
       {
         code: `
-      <div
-        className={clsx(
-          "w-full h-10 rounded",
-          name === "white"
-            ? "ring-black flex"
-            : undefined
-        )}
-      />
-      `,
+        <div
+          className={clsx(
+            "w-full h-10 rounded",
+            name === "white"
+              ? "ring-black flex"
+              : undefined
+          )}
+        />
+        `,
         output: `
-      <div
-        className={clsx(
-          "h-10 w-full rounded",
-          name === "white"
-            ? "flex ring-black"
-            : undefined
-        )}
-      />
-      `,
+        <div
+          className={clsx(
+            "h-10 w-full rounded",
+            name === "white"
+              ? "flex ring-black"
+              : undefined
+          )}
+        />
+        `,
         errors: [error, error],
       },
       {
@@ -504,48 +611,48 @@ ruleTester.run(RULE_NAME, classnamesOrder, {
       },
       {
         code: `
-      const myTag = {
-        subTag: (strings) => {
-          return \`$\{strings}\`;
-        }
-      };
-      const classes = myTag.subTag\`flex unknown relative\`;
-      `,
+        const myTag = {
+          subTag: (strings) => {
+            return \`$\{strings}\`;
+          }
+        };
+        const classes = myTag.subTag\`flex unknown relative\`;
+        `,
         output: `
-      const myTag = {
-        subTag: (strings) => {
-          return \`$\{strings}\`;
-        }
-      };
-      const classes = myTag.subTag\`unknown relative flex\`;
-      `,
+        const myTag = {
+          subTag: (strings) => {
+            return \`$\{strings}\`;
+          }
+        };
+        const classes = myTag.subTag\`unknown relative flex\`;
+        `,
         settings: { tailwindcss: { ...generalSettings, functions: ["myTag"] } },
         errors: errors,
       },
       {
         code: `
-      import tw from 'twin.macro';
-      const Input = tw.input\`flex unknown relative\`;
-      const PurpleInput = tw(Input)\`flex unknown relative\`;
-      `,
+        import tw from 'twin.macro';
+        const Input = tw.input\`flex unknown relative\`;
+        const PurpleInput = tw(Input)\`flex unknown relative\`;
+        `,
         output: `
-      import tw from 'twin.macro';
-      const Input = tw.input\`unknown relative flex\`;
-      const PurpleInput = tw(Input)\`unknown relative flex\`;
-      `,
+        import tw from 'twin.macro';
+        const Input = tw.input\`unknown relative flex\`;
+        const PurpleInput = tw(Input)\`unknown relative flex\`;
+        `,
         errors: [error, error],
       },
       {
         code: `
-      classnames([
-        'invalid lg:w-4 sm:w-6',
-        ['w-12 flex'],
-      ])`,
+        classnames([
+          'invalid lg:w-4 sm:w-6',
+          ['w-12 flex'],
+        ])`,
         output: `
-      classnames([
-        'invalid sm:w-6 lg:w-4',
-        ['flex w-12'],
-      ])`,
+        classnames([
+          'invalid sm:w-6 lg:w-4',
+          ['flex w-12'],
+        ])`,
         errors: [error, error],
       },
       {
@@ -560,36 +667,36 @@ ruleTester.run(RULE_NAME, classnamesOrder, {
       },
       {
         code: `
-      ctl(\`
-        m-0!
-        !absolute
-        w-[\${width}]
-        rounded
-        blur-2xl
-        flex
-        h-[\${height}]
-      \`);`,
+        ctl(\`
+          m-0!
+          !absolute
+          w-[\${width}]
+          rounded
+          blur-2xl
+          flex
+          h-[\${height}]
+        \`);`,
         output: `
-      ctl(\`
-        !absolute
-        m-0!
-        w-[\${width}]
-        flex
-        rounded
-        blur-2xl
-        h-[\${height}]
-      \`);`,
+        ctl(\`
+          !absolute
+          m-0!
+          w-[\${width}]
+          flex
+          rounded
+          blur-2xl
+          h-[\${height}]
+        \`);`,
         errors: [error, error, error, error, error],
       },
       {
         code: `
-      ctl(\`
-        m-0 absolute w-[\${width}] blur-2xl flex
-      \`);`,
+        ctl(\`
+          m-0 absolute w-[\${width}] blur-2xl flex
+        \`);`,
         output: `
-      ctl(\`
-        absolute m-0 w-[\${width}] flex blur-2xl
-      \`);`,
+        ctl(\`
+          absolute m-0 w-[\${width}] flex blur-2xl
+        \`);`,
         errors: [error, error, error, error],
       },
       {

--- a/src/rules/classnames-order.wip.spec.ts
+++ b/src/rules/classnames-order.wip.spec.ts
@@ -1,0 +1,88 @@
+import * as Parser from "@typescript-eslint/parser";
+import { RuleTester, TestCaseError } from "@typescript-eslint/rule-tester";
+
+import {
+  generalSettings,
+  withSvelteParser,
+} from "../utils/parser/test-helpers";
+import {
+  classnamesOrder,
+  type MessageIds,
+  RULE_NAME,
+} from "./classnames-order";
+
+const error: TestCaseError<MessageIds> = { messageId: "fix:sort" };
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: Parser,
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+  settings: {
+    tailwindcss: {
+      ...generalSettings,
+    },
+  },
+});
+
+ruleTester.run(RULE_NAME, classnamesOrder, {
+  valid: [],
+  invalid: [
+    // Svelte
+    {
+      code: `
+        <script>
+          const styles = tw\`block absolute\`;
+        </script>
+        <section class="p-6">Simple</section>`,
+      output: `
+        <script>
+          const styles = tw\`absolute block\`;
+        </script>
+        <section class="p-6">Simple</section>`,
+      languageOptions: withSvelteParser,
+      errors: [error, error],
+    },
+    {
+      code: `
+        <script>
+          const styles = tw\`block absolute\`;
+          const ctl = ctl('relative unkown')
+          const isDarkMode = true;
+        </script>
+        <section class="p-10 w-full {isDarkMode ? 'bg-slate-900 h-full' : 'bg-white flex'}">
+          <span  class="text-xs font-bold {ctl}" class:bg-amber-500={isDarkMode}>
+            Class binding
+          </span>
+        </section>`,
+      output: `
+        <script>
+          const styles = tw\`absolute block\`;
+          const ctl = ctl('unkown relative')
+          const isDarkMode = true;
+        </script>
+        <section class="w-full p-10 {isDarkMode ? 'h-full bg-slate-900' : 'flex bg-white'}">
+          <span  class="text-xs font-bold {ctl}" class:bg-amber-500={isDarkMode}>
+            Class binding
+          </span>
+        </section>`,
+      languageOptions: withSvelteParser,
+      errors: [
+        error,
+        error,
+        error,
+        error,
+        error,
+        error,
+        error,
+        error,
+        error,
+        error,
+      ],
+    },
+  ],
+});

--- a/src/rules/no-custom-classname.spec.ts
+++ b/src/rules/no-custom-classname.spec.ts
@@ -6,6 +6,7 @@ import {
   generalSettings,
   prefixedSettings,
   withAngularParser,
+  withSvelteParser,
 } from "../utils/parser/test-helpers";
 import {
   MessageIds,
@@ -50,8 +51,8 @@ const ruleTester = new RuleTester({
 
 ruleTester.run(RULE_NAME, noCustomClassname, {
   valid: [
+    // Angular / Native HTML + static text
     ...[
-      // Angular / Native HTML + static text
       `<h1 class="whitelisted flex">attributeVisitor with TextAttribute (single class gets skipped)</h1>`,
       `<h1 class="  relative ">extra spaces</h1>`,
       `<h1 class=" relative " className=' flex'>Single + double quotes</h1>`,
@@ -78,8 +79,8 @@ ruleTester.run(RULE_NAME, noCustomClassname, {
       ],
       languageOptions: withAngularParser,
     })),
+    // React
     ...[
-      // React
       `<h1 className={\`max-w-full \${isDone ? 'opacity-80 grayscale' : null}\`}>null</h1>`,
       // Issue 252
       `twJoin('h-full', selectedPickupPoint === pickupPoint && 'absolute')`,
@@ -151,379 +152,506 @@ ruleTester.run(RULE_NAME, noCustomClassname, {
     ].map((jsx) => ({
       code: jsx,
     })),
+    // Svelte
     ...[
-      // Issue 313
-      `ctl('tw:flex tw:@container tw:@lg:hidden')`,
-    ].map((jsx) => ({
+      `
+      <script>
+        const styles = tw\`block absolute\`;
+      </script>
+      <section class="p-6">Simple</section>`,
+      `
+      <script>
+        let isExpanded = false;
+      </script>
+      <div
+        class="w-1/2"
+        class:hover:w-full={!isExpanded}
+      >
+        Svelte
+      </div>`,
+    ].map((svelteCode) => ({
+      code: svelteCode,
+      languageOptions: withSvelteParser,
+    })),
+    // Issue 313 prefix in settings
+    ...[`ctl('tw:flex tw:@container tw:@lg:hidden')`].map((jsx) => ({
       code: jsx,
       settings: { tailwindcss: { ...prefixedSettings } },
     })),
-    ...[
-      // Issue 406
-      `ctl('modal')`,
-    ].map((jsx) => ({
+    // Issue 406 Using external libs such as DaisyUI
+    ...[`ctl('modal')`].map((jsx) => ({
       code: jsx,
       settings: { tailwindcss: { ...daisySettings } },
     })),
   ],
   invalid: [
-    {
-      code: `<h1 class="unknown relative">head</h1>`,
-      errors: [suggest("unknown", `<h1 class="relative">head</h1>`)],
+    // Angular / Native HTML + static text
+    ...[
+      {
+        code: `<h1 class="unknown relative">head</h1>`,
+        errors: [suggest("unknown", `<h1 class="relative">head</h1>`)],
+      },
+      {
+        code: `<h1 class="relative unknown flex">body</h1>`,
+        errors: [suggest("unknown", `<h1 class="relative flex">body</h1>`)],
+      },
+      {
+        code: `<h1 class="relative unknown">tail</h1>`,
+        errors: [suggest("unknown", `<h1 class="relative">tail</h1>`)],
+      },
+    ].map(({ code, errors }) => ({
+      code: code,
+      errors: errors,
       languageOptions: withAngularParser,
-    },
-    {
-      code: `<h1 class="relative unknown flex">body</h1>`,
-      errors: [suggest("unknown", `<h1 class="relative flex">body</h1>`)],
-      languageOptions: withAngularParser,
-    },
-    {
-      code: `<h1 class="relative unknown">tail</h1>`,
-      errors: [suggest("unknown", `<h1 class="relative">tail</h1>`)],
-      languageOptions: withAngularParser,
-    },
-    {
-      code: `<h1 className={"unknownreact relative"}>head</h1>`,
-      errors: [suggest("unknownreact", `<h1 className={"relative"}>head</h1>`)],
-    },
-    {
-      code: `<h1 className={"yolo:bg-red"}>validate-modifiers</h1>`,
-      errors: [
-        suggest("yolo:bg-red", `<h1 className={""}>validate-modifiers</h1>`),
-      ],
-    },
-    {
-      code: `<h1 className={"last-child:mb-0"}>invalid modifier, Issue 305</h1>`,
-      errors: [
-        suggest(
-          "last-child:mb-0",
-          `<h1 className={""}>invalid modifier, Issue 305</h1>`,
-        ),
-      ],
-    },
-    {
-      code: "<h1 className={`unknown:flex relative`}>Invalid modifier</h1>",
-      errors: [
-        suggest(
-          "unknown:flex",
-          "<h1 className={`relative`}>Invalid modifier</h1>",
-        ),
-      ],
-    },
-    {
-      code: `ctl(\`unknownreact relative\`)`,
-      errors: [suggest("unknownreact", `ctl(\`relative\`)`)],
-    },
-    {
-      code: `
-      ctl(\`
-        unknownreact
-        relative
-      \`)`,
-      errors: [
-        suggest(
-          "unknownreact",
-          `
-      ctl(\`
-        relative
-      \`)`,
-        ),
-      ],
-    },
-    {
-      code: `
-      ctl(\`
-        absolute
-        unknown-react
-        relative
-      \`)`,
-      errors: [
-        suggest(
-          "unknown-react",
-          `
-      ctl(\`
-        absolute
-        relative
-      \`)`,
-        ),
-      ],
-    },
-    {
-      code: `<h1 class="relative unknown">tail</h1>`,
-      errors: [suggest("unknown", `<h1 class="relative">tail</h1>`)],
-    },
-    {
-      // Issue 264 Strings (variadic)
-      code: `clsx('flex', true && 'unknown', 'unknown-bis');`,
-      errors: [
-        suggest("unknown", `clsx('flex', true && '', 'unknown-bis');`),
-        suggest("unknown-bis", `clsx('flex', true && 'unknown', '');`),
-      ],
-    },
-    {
-      // Issue 264 Objects
-      code: `clsx({ foo:true, absolute:false, baz:isTrue() });`,
-      errors: [
-        // An identifier node is not fixable, we only report
-        suggest("foo"),
-        // An identifier node is not fixable, we only report
-        suggest("baz"),
-      ],
-    },
-    {
-      // Issue 264 Objects (variadic)
-      code: `clsx({ foo:true }, { bar:false }, null, { '--foobar':'hello' });`,
-      errors: [
-        // An identifier node is not fixable, we only report
-        suggest("foo"),
-        // An identifier node is not fixable, we only report
-        suggest("baz"),
-        // An identifier node is not fixable, we only report
-        suggest(
-          "--foobar",
-          `clsx({ foo:true }, { bar:false }, null, { '':'hello' });`,
-        ),
-      ],
-    },
-    {
-      // Issue 264 Arrays
-      code: `clsx(['foo', 0, false, 'bar']);`,
-      errors: [
-        suggest("foo", `clsx(['', 0, false, 'bar']);`),
-        suggest("bar", `clsx(['foo', 0, false, '']);`),
-      ],
-    },
-    {
-      // Issue 264 Arrays (variadic)
-      code: `clsx(['foo'], ['', 0, false, 'bar'], [['baz', [['hello'], 'there']]]);`,
-      errors: [
-        suggest(
-          "foo",
-          `clsx([''], ['', 0, false, 'bar'], [['baz', [['hello'], 'there']]]);`,
-        ),
-        suggest(
-          "bar",
-          `clsx(['foo'], ['', 0, false, ''], [['baz', [['hello'], 'there']]]);`,
-        ),
-        suggest(
-          "baz",
-          `clsx(['foo'], ['', 0, false, 'bar'], [['', [['hello'], 'there']]]);`,
-        ),
-        suggest(
-          "hello",
-          `clsx(['foo'], ['', 0, false, 'bar'], [['baz', [[''], 'there']]]);`,
-        ),
-        suggest(
-          "there",
-          `clsx(['foo'], ['', 0, false, 'bar'], [['baz', [['hello'], '']]]);`,
-        ),
-      ],
-    },
-    {
-      // Issue 264 Kitchen sink (with nesting)
-      code: `clsx('foo', [1 && 'bar', { baz:false, bat:null }, ['hello', ['world']]], 'cya');`,
-      errors: [
-        suggest(
-          "foo",
-          `clsx('', [1 && 'bar', { baz:false, bat:null }, ['hello', ['world']]], 'cya');`,
-        ),
-        suggest(
-          "bar",
-          `clsx('foo', [1 && '', { baz:false, bat:null }, ['hello', ['world']]], 'cya');`,
-        ),
-        suggest("baz"),
-        suggest("bat"),
-        suggest(
-          "hello",
-          `clsx('foo', [1 && 'bar', { baz:false, bat:null }, ['', ['world']]], 'cya');`,
-        ),
-        suggest(
-          "world",
-          `clsx('foo', [1 && 'bar', { baz:false, bat:null }, ['hello', ['']]], 'cya');`,
-        ),
-        suggest(
-          "cya",
-          `clsx('foo', [1 && 'bar', { baz:false, bat:null }, ['hello', ['world']]], '');`,
-        ),
-      ],
-    },
-    {
-      // Issue 422
-      code: `
-      tv({
-        slots: {
-          base: 'flex unknown-base',
-          item: 'data-[active="true"]:text-white',
-        },
-        variants: {
-          size: {
-            xs: 'absolute',
-            sm: 'unknown-sm',
-          }
-        },
-        defaultVariants: {
-          size: 'xs'
-        },
-        compoundSlots: [
-          // if you dont specify any variant, it will always be applied
-          {
-            slots: ['item', 'prev', 'next'],
-            class: [
-              'unknown-compound block',
-              'text-black'
-            ] // --> these classes will be applied to all slots
-          },
-          // if you specify a variant, it will only be applied if the variant is active
-          {
-            slots: ['item', 'prev', 'next'],
-            size: 'xs',
-            class: 'unknown-multiple' // --> these classes will be applied to all slots if size is xs
-          },
-        ]
-      });`,
-      errors: [
-        suggest(
-          "unknown-base",
-          `
-      tv({
-        slots: {
-          base: 'flex',
-          item: 'data-[active="true"]:text-white',
-        },
-        variants: {
-          size: {
-            xs: 'absolute',
-            sm: 'unknown-sm',
-          }
-        },
-        defaultVariants: {
-          size: 'xs'
-        },
-        compoundSlots: [
-          // if you dont specify any variant, it will always be applied
-          {
-            slots: ['item', 'prev', 'next'],
-            class: [
-              'unknown-compound block',
-              'text-black'
-            ] // --> these classes will be applied to all slots
-          },
-          // if you specify a variant, it will only be applied if the variant is active
-          {
-            slots: ['item', 'prev', 'next'],
-            size: 'xs',
-            class: 'unknown-multiple' // --> these classes will be applied to all slots if size is xs
-          },
-        ]
-      });`,
-        ),
-        suggest(
-          "unknown-sm",
-          `
-      tv({
-        slots: {
-          base: 'flex unknown-base',
-          item: 'data-[active="true"]:text-white',
-        },
-        variants: {
-          size: {
-            xs: 'absolute',
-            sm: '',
-          }
-        },
-        defaultVariants: {
-          size: 'xs'
-        },
-        compoundSlots: [
-          // if you dont specify any variant, it will always be applied
-          {
-            slots: ['item', 'prev', 'next'],
-            class: [
-              'unknown-compound block',
-              'text-black'
-            ] // --> these classes will be applied to all slots
-          },
-          // if you specify a variant, it will only be applied if the variant is active
-          {
-            slots: ['item', 'prev', 'next'],
-            size: 'xs',
-            class: 'unknown-multiple' // --> these classes will be applied to all slots if size is xs
-          },
-        ]
-      });`,
-        ),
-        suggest(
-          "unknown-compound",
-          `
-      tv({
-        slots: {
-          base: 'flex unknown-base',
-          item: 'data-[active="true"]:text-white',
-        },
-        variants: {
-          size: {
-            xs: 'absolute',
-            sm: 'unknown-sm',
-          }
-        },
-        defaultVariants: {
-          size: 'xs'
-        },
-        compoundSlots: [
-          // if you dont specify any variant, it will always be applied
-          {
-            slots: ['item', 'prev', 'next'],
-            class: [
-              'block',
-              'text-black'
-            ] // --> these classes will be applied to all slots
-          },
-          // if you specify a variant, it will only be applied if the variant is active
-          {
-            slots: ['item', 'prev', 'next'],
-            size: 'xs',
-            class: 'unknown-multiple' // --> these classes will be applied to all slots if size is xs
-          },
-        ]
-      });`,
-        ),
-        suggest(
-          "unknown-multiple",
-          `
-      tv({
-        slots: {
-          base: 'flex unknown-base',
-          item: 'data-[active="true"]:text-white',
-        },
-        variants: {
-          size: {
-            xs: 'absolute',
-            sm: 'unknown-sm',
-          }
-        },
-        defaultVariants: {
-          size: 'xs'
-        },
-        compoundSlots: [
-          // if you dont specify any variant, it will always be applied
-          {
-            slots: ['item', 'prev', 'next'],
-            class: [
-              'unknown-compound block',
-              'text-black'
-            ] // --> these classes will be applied to all slots
-          },
-          // if you specify a variant, it will only be applied if the variant is active
-          {
-            slots: ['item', 'prev', 'next'],
-            size: 'xs',
-            class: '' // --> these classes will be applied to all slots if size is xs
-          },
-        ]
-      });`,
-        ),
-      ],
-    },
+    })),
+    // React
+    ...[
+      {
+        code: `<h1 className={"unknownreact relative"}>head</h1>`,
+        errors: [
+          suggest("unknownreact", `<h1 className={"relative"}>head</h1>`),
+        ],
+      },
+      {
+        code: `<h1 className={"yolo:bg-red"}>validate-modifiers</h1>`,
+        errors: [
+          suggest("yolo:bg-red", `<h1 className={""}>validate-modifiers</h1>`),
+        ],
+      },
+      {
+        code: `<h1 className={"last-child:mb-0"}>invalid modifier, Issue 305</h1>`,
+        errors: [
+          suggest(
+            "last-child:mb-0",
+            `<h1 className={""}>invalid modifier, Issue 305</h1>`,
+          ),
+        ],
+      },
+      {
+        code: "<h1 className={`unknown:flex relative`}>Invalid modifier</h1>",
+        errors: [
+          suggest(
+            "unknown:flex",
+            "<h1 className={`relative`}>Invalid modifier</h1>",
+          ),
+        ],
+      },
+      {
+        code: `ctl(\`unknownreact relative\`)`,
+        errors: [suggest("unknownreact", `ctl(\`relative\`)`)],
+      },
+      {
+        code: `
+        ctl(\`
+          unknownreact
+          relative
+        \`)`,
+        errors: [
+          suggest(
+            "unknownreact",
+            `
+        ctl(\`
+          relative
+        \`)`,
+          ),
+        ],
+      },
+      {
+        code: `
+        ctl(\`
+          absolute
+          unknown-react
+          relative
+        \`)`,
+        errors: [
+          suggest(
+            "unknown-react",
+            `
+        ctl(\`
+          absolute
+          relative
+        \`)`,
+          ),
+        ],
+      },
+      {
+        code: `<h1 class="relative unknown">tail</h1>`,
+        errors: [suggest("unknown", `<h1 class="relative">tail</h1>`)],
+      },
+    ].map(({ code, errors }) => ({
+      code: code,
+      errors: errors,
+    })),
+    // clsx()
+    ...[
+      {
+        // Issue 264 Strings (variadic)
+        code: `clsx('flex', true && 'unknown', 'unknown-bis');`,
+        errors: [
+          suggest("unknown", `clsx('flex', true && '', 'unknown-bis');`),
+          suggest("unknown-bis", `clsx('flex', true && 'unknown', '');`),
+        ],
+      },
+      {
+        // Issue 264 Objects
+        code: `clsx({ foo:true, absolute:false, baz:isTrue() });`,
+        errors: [
+          // An identifier node is not fixable, we only report
+          suggest("foo"),
+          // An identifier node is not fixable, we only report
+          suggest("baz"),
+        ],
+      },
+      {
+        // Issue 264 Objects (variadic)
+        code: `clsx({ foo:true }, { bar:false }, null, { '--foobar':'hello' });`,
+        errors: [
+          // An identifier node is not fixable, we only report
+          suggest("foo"),
+          // An identifier node is not fixable, we only report
+          suggest("baz"),
+          // An identifier node is not fixable, we only report
+          suggest(
+            "--foobar",
+            `clsx({ foo:true }, { bar:false }, null, { '':'hello' });`,
+          ),
+        ],
+      },
+      {
+        // Issue 264 Arrays
+        code: `clsx(['foo', 0, false, 'bar']);`,
+        errors: [
+          suggest("foo", `clsx(['', 0, false, 'bar']);`),
+          suggest("bar", `clsx(['foo', 0, false, '']);`),
+        ],
+      },
+      {
+        // Issue 264 Arrays (variadic)
+        code: `clsx(['foo'], ['', 0, false, 'bar'], [['baz', [['hello'], 'there']]]);`,
+        errors: [
+          suggest(
+            "foo",
+            `clsx([''], ['', 0, false, 'bar'], [['baz', [['hello'], 'there']]]);`,
+          ),
+          suggest(
+            "bar",
+            `clsx(['foo'], ['', 0, false, ''], [['baz', [['hello'], 'there']]]);`,
+          ),
+          suggest(
+            "baz",
+            `clsx(['foo'], ['', 0, false, 'bar'], [['', [['hello'], 'there']]]);`,
+          ),
+          suggest(
+            "hello",
+            `clsx(['foo'], ['', 0, false, 'bar'], [['baz', [[''], 'there']]]);`,
+          ),
+          suggest(
+            "there",
+            `clsx(['foo'], ['', 0, false, 'bar'], [['baz', [['hello'], '']]]);`,
+          ),
+        ],
+      },
+      {
+        // Issue 264 Kitchen sink (with nesting)
+        code: `clsx('foo', [1 && 'bar', { baz:false, bat:null }, ['hello', ['world']]], 'cya');`,
+        errors: [
+          suggest(
+            "foo",
+            `clsx('', [1 && 'bar', { baz:false, bat:null }, ['hello', ['world']]], 'cya');`,
+          ),
+          suggest(
+            "bar",
+            `clsx('foo', [1 && '', { baz:false, bat:null }, ['hello', ['world']]], 'cya');`,
+          ),
+          suggest("baz"),
+          suggest("bat"),
+          suggest(
+            "hello",
+            `clsx('foo', [1 && 'bar', { baz:false, bat:null }, ['', ['world']]], 'cya');`,
+          ),
+          suggest(
+            "world",
+            `clsx('foo', [1 && 'bar', { baz:false, bat:null }, ['hello', ['']]], 'cya');`,
+          ),
+          suggest(
+            "cya",
+            `clsx('foo', [1 && 'bar', { baz:false, bat:null }, ['hello', ['world']]], '');`,
+          ),
+        ],
+      },
+    ].map(({ code, errors }) => ({
+      code: code,
+      errors: errors,
+    })),
+    // tv()
+    ...[
+      {
+        // Issue 422
+        code: `
+          tv({
+            slots: {
+              base: 'flex unknown-base',
+              item: 'data-[active="true"]:text-white',
+            },
+            variants: {
+              size: {
+                xs: 'absolute',
+                sm: 'unknown-sm',
+              }
+            },
+            defaultVariants: {
+              size: 'xs'
+            },
+            compoundSlots: [
+              // if you dont specify any variant, it will always be applied
+              {
+                slots: ['item', 'prev', 'next'],
+                class: [
+                  'unknown-compound block',
+                  'text-black'
+                ] // --> these classes will be applied to all slots
+              },
+              // if you specify a variant, it will only be applied if the variant is active
+              {
+                slots: ['item', 'prev', 'next'],
+                size: 'xs',
+                class: 'unknown-multiple' // --> these classes will be applied to all slots if size is xs
+              },
+            ]
+          });`,
+        errors: [
+          suggest(
+            "unknown-base",
+            `
+          tv({
+            slots: {
+              base: 'flex',
+              item: 'data-[active="true"]:text-white',
+            },
+            variants: {
+              size: {
+                xs: 'absolute',
+                sm: 'unknown-sm',
+              }
+            },
+            defaultVariants: {
+              size: 'xs'
+            },
+            compoundSlots: [
+              // if you dont specify any variant, it will always be applied
+              {
+                slots: ['item', 'prev', 'next'],
+                class: [
+                  'unknown-compound block',
+                  'text-black'
+                ] // --> these classes will be applied to all slots
+              },
+              // if you specify a variant, it will only be applied if the variant is active
+              {
+                slots: ['item', 'prev', 'next'],
+                size: 'xs',
+                class: 'unknown-multiple' // --> these classes will be applied to all slots if size is xs
+              },
+            ]
+          });`,
+          ),
+          suggest(
+            "unknown-sm",
+            `
+          tv({
+            slots: {
+              base: 'flex unknown-base',
+              item: 'data-[active="true"]:text-white',
+            },
+            variants: {
+              size: {
+                xs: 'absolute',
+                sm: '',
+              }
+            },
+            defaultVariants: {
+              size: 'xs'
+            },
+            compoundSlots: [
+              // if you dont specify any variant, it will always be applied
+              {
+                slots: ['item', 'prev', 'next'],
+                class: [
+                  'unknown-compound block',
+                  'text-black'
+                ] // --> these classes will be applied to all slots
+              },
+              // if you specify a variant, it will only be applied if the variant is active
+              {
+                slots: ['item', 'prev', 'next'],
+                size: 'xs',
+                class: 'unknown-multiple' // --> these classes will be applied to all slots if size is xs
+              },
+            ]
+          });`,
+          ),
+          suggest(
+            "unknown-compound",
+            `
+          tv({
+            slots: {
+              base: 'flex unknown-base',
+              item: 'data-[active="true"]:text-white',
+            },
+            variants: {
+              size: {
+                xs: 'absolute',
+                sm: 'unknown-sm',
+              }
+            },
+            defaultVariants: {
+              size: 'xs'
+            },
+            compoundSlots: [
+              // if you dont specify any variant, it will always be applied
+              {
+                slots: ['item', 'prev', 'next'],
+                class: [
+                  'block',
+                  'text-black'
+                ] // --> these classes will be applied to all slots
+              },
+              // if you specify a variant, it will only be applied if the variant is active
+              {
+                slots: ['item', 'prev', 'next'],
+                size: 'xs',
+                class: 'unknown-multiple' // --> these classes will be applied to all slots if size is xs
+              },
+            ]
+          });`,
+          ),
+          suggest(
+            "unknown-multiple",
+            `
+          tv({
+            slots: {
+              base: 'flex unknown-base',
+              item: 'data-[active="true"]:text-white',
+            },
+            variants: {
+              size: {
+                xs: 'absolute',
+                sm: 'unknown-sm',
+              }
+            },
+            defaultVariants: {
+              size: 'xs'
+            },
+            compoundSlots: [
+              // if you dont specify any variant, it will always be applied
+              {
+                slots: ['item', 'prev', 'next'],
+                class: [
+                  'unknown-compound block',
+                  'text-black'
+                ] // --> these classes will be applied to all slots
+              },
+              // if you specify a variant, it will only be applied if the variant is active
+              {
+                slots: ['item', 'prev', 'next'],
+                size: 'xs',
+                class: '' // --> these classes will be applied to all slots if size is xs
+              },
+            ]
+          });`,
+          ),
+        ],
+      },
+    ].map(({ code, errors }) => ({
+      code: code,
+      errors: errors,
+    })),
+    // Svelte
+    ...[
+      {
+        code: `
+        <script>
+          const styles = tw\`unknown\`;
+        </script>
+        <section class="p-6 foo">Simple</section>`,
+        errors: [
+          suggest(
+            "unknown",
+            `
+        <script>
+          const styles = tw\`\`;
+        </script>
+        <section class="p-6 foo">Simple</section>`,
+          ),
+          suggest(
+            "foo",
+            `
+        <script>
+          const styles = tw\`unknown\`;
+        </script>
+        <section class="p-6">Simple</section>`,
+          ),
+        ],
+      },
+      {
+        code: `
+        <script>
+          let isExpanded = false;
+        </script>
+        <div
+          class="block z-1/2 relative {isExpanded ? 'foo' : 'baz'}"
+          class:hover:x-full={!isExpanded}
+        >
+          Svelte
+        </div>`,
+        errors: [
+          suggest(
+            "z-1/2",
+            `
+        <script>
+          let isExpanded = false;
+        </script>
+        <div
+          class="block relative {isExpanded ? 'foo' : 'baz'}"
+          class:hover:x-full={!isExpanded}
+        >
+          Svelte
+        </div>`,
+          ),
+          suggest(
+            "foo",
+            `
+        <script>
+          let isExpanded = false;
+        </script>
+        <div
+          class="block z-1/2 relative {isExpanded ? '' : 'baz'}"
+          class:hover:x-full={!isExpanded}
+        >
+          Svelte
+        </div>`,
+          ),
+          suggest(
+            "baz",
+            `
+        <script>
+          let isExpanded = false;
+        </script>
+        <div
+          class="block z-1/2 relative {isExpanded ? 'foo' : ''}"
+          class:hover:x-full={!isExpanded}
+        >
+          Svelte
+        </div>`,
+          ),
+          suggest("hover:x-full"),
+        ],
+      },
+    ].map(({ code, errors }) => ({
+      code: code,
+      errors: errors,
+      languageOptions: withSvelteParser,
+    })),
     /*/
     {
       // At this moment, no possibility to read the custom dark variant from the config

--- a/src/rules/no-custom-classname.ts
+++ b/src/rules/no-custom-classname.ts
@@ -126,7 +126,10 @@ const detectCustomClassnames = (
 
     // 2. Emit reports with a surgical fix (one class targeted)
     for (const invalidClass of invalidClassesInNode) {
-      const fixable = invalidClass.type !== TSESTree.AST_NODE_TYPES.Identifier;
+      const fixable = ![
+        TSESTree.AST_NODE_TYPES.Identifier,
+        "SvelteName",
+      ].includes(invalidClass.type);
       const patchedLoc = generateLocForClassname(
         node,
         invalidClass.classname,

--- a/src/utils/parser/node.ts
+++ b/src/utils/parser/node.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST as SvelteAST } from "svelte-eslint-parser";
 import { AST as VueAST } from "vue-eslint-parser";
 
 import { AtomicNode } from "../rule";
@@ -144,6 +145,17 @@ export const getJSXAttributeName = (node: TSESTree.JSXAttribute): string => {
 
 /**
  * @example
+ * getSvelteAttributeName(<div class="flex" />); // class
+ * getSvelteAttributeName(<div ns:demo="flex" />); // ns:demo
+ */
+export const getSvelteAttributeName = (
+  node: SvelteAST.SvelteAttribute,
+): string => {
+  return node.key.name;
+};
+
+/**
+ * @example
  * getVAttributeName(<template><p class="flex"></p></template>); // class
  * getVAttributeName(<template><p v-bind:class="classes"></p></template>); // class
  */
@@ -200,6 +212,13 @@ export const dissectAtomicNode = (
       [start, end] = node.range;
       start++;
       end--;
+      break;
+    }
+    case "SvelteLiteral": {
+      if (typeof node.value !== "string") break;
+      if (node.value === "") break;
+      originalClassNamesValue = "" + node.value;
+      [start, end] = node.range;
       break;
     }
     case TSESTree.AST_NODE_TYPES.TemplateElement: {

--- a/src/utils/parser/node.ts
+++ b/src/utils/parser/node.ts
@@ -221,6 +221,13 @@ export const dissectAtomicNode = (
       [start, end] = node.range;
       break;
     }
+    case "SvelteName": {
+      if (typeof node.name !== "string") break;
+      if (node.name === "") break;
+      originalClassNamesValue = "" + node.name;
+      [start, end] = node.range;
+      break;
+    }
     case TSESTree.AST_NODE_TYPES.TemplateElement: {
       originalClassNamesValue = node.value.raw;
       if (originalClassNamesValue === "") break;

--- a/src/utils/parser/test-helpers.ts
+++ b/src/utils/parser/test-helpers.ts
@@ -103,12 +103,33 @@ const getFirstJSXOpeningElement = (code: string) => {
   return body.expression.openingElement;
 };
 
+const getFirstSvelteOpeningElement = (code: string) => {
+  const parsed = svelteParser.parseForESLint(code);
+  const body = parsed.ast.body.at(0);
+  if (body === undefined) {
+    throw new Error("No Body found");
+  }
+  if (body.type !== "SvelteElement") {
+    throw new Error("No SvelteElement found");
+  }
+  if (body.startTag.type !== "SvelteStartTag") {
+    throw new Error("No SvelteStartTag found");
+  }
+  return body.startTag;
+};
+
 const getJSXAttribute = (node: TSESTree.JSXOpeningElement) => {
   const jsxAttribute = node.attributes.at(0);
   if (jsxAttribute === undefined) throw new Error("No JSXAttribute found");
   if (jsxAttribute.type === TSESTree.AST_NODE_TYPES.JSXSpreadAttribute)
     throw new Error("Unsupported JSXSpreadAttribute found");
   return jsxAttribute;
+};
+
+const getSvelteAttribute = (node: svelteParser.AST.SvelteStartTag) => {
+  const svelteAttribute = node.attributes.at(0);
+  if (svelteAttribute === undefined) throw new Error("No SvelteElement found");
+  return svelteAttribute;
 };
 
 const getFirstVOpeningElement = (code: string) => {
@@ -138,6 +159,11 @@ export const _htmlAttribute = (code: string) => {
 export const _jsxAttribute = (code: string) => {
   const jsxElement = getFirstJSXOpeningElement(code);
   return getJSXAttribute(jsxElement);
+};
+
+export const _svelteAttribute = (code: string) => {
+  const svelteElement = getFirstSvelteOpeningElement(code);
+  return getSvelteAttribute(svelteElement);
 };
 
 export const _vAttribute = (code: string) => {

--- a/src/utils/parser/test-helpers.ts
+++ b/src/utils/parser/test-helpers.ts
@@ -4,6 +4,7 @@ import * as Parser from "@typescript-eslint/parser";
 import { TestLanguageOptions } from "@typescript-eslint/rule-tester";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
 import { TSESTree } from "@typescript-eslint/utils";
+import svelteParser from "svelte-eslint-parser";
 import * as VueParser from "vue-eslint-parser";
 import { VStartTag } from "vue-eslint-parser/ast/index";
 
@@ -18,6 +19,10 @@ export const withJSX = {
 
 export const withAngularParser: TestLanguageOptions = {
   parser: AngularParser,
+};
+
+export const withSvelteParser: TestLanguageOptions = {
+  parser: svelteParser,
 };
 
 export const withVueParser: TestLanguageOptions = {

--- a/src/utils/parser/visitors-validation.spec.ts
+++ b/src/utils/parser/visitors-validation.spec.ts
@@ -1,4 +1,5 @@
 import { TSESTree } from "@typescript-eslint/utils";
+import { SvelteAttribute } from "svelte-eslint-parser/lib/ast";
 import { expect, test } from "vitest";
 
 import { parsePluginSettings, PluginSettings } from "../parse-plugin-settings";
@@ -6,6 +7,7 @@ import {
   _callExpression,
   _htmlAttribute,
   _jsxAttribute,
+  _svelteAttribute,
   _vAttribute,
 } from "./test-helpers";
 import {
@@ -13,6 +15,7 @@ import {
   isValidCallExpression,
   isValidExpressionAttributeValue,
   isValidJSXAttribute,
+  isValidSvelteAttribute,
   isValidTextAttribute,
   isValidVAttribute,
 } from "./visitors-validation";
@@ -45,6 +48,40 @@ test("isValidJSXAttribute", () => {
   valid.map(([input, settings]) => {
     const node = _jsxAttribute(input);
     expect(isValidJSXAttribute(node, settings)).toBe(true);
+  });
+});
+
+test("isValidSvelteAttribute", () => {
+  type TestConfig = [string, PluginSettings];
+  // Valid expressions
+  const valid: Array<TestConfig> = [
+    // Defaults
+    [`<p class="value">p</p>`, defaultSettings],
+    [
+      `<p class={{ "block absolute": shown, "size-0 invisible": !shown }}>p</p>`,
+      defaultSettings,
+    ],
+    [
+      `<div class={[faded && 'saturate-0 opacity-50', large && 'scale-200']}>...</div>`,
+      defaultSettings,
+    ],
+    [`<div class={['block absolute', props.class]}>...</div>`, defaultSettings],
+  ];
+  valid.map(([input, settings]) => {
+    const node = _svelteAttribute(input);
+    expect(isValidSvelteAttribute(node as SvelteAttribute, settings)).toBe(
+      true,
+    );
+  });
+  const invalid: Array<TestConfig> = [
+    // Defaults
+    [`<img alt src />`, defaultSettings],
+  ];
+  invalid.map(([input, settings]) => {
+    const node = _svelteAttribute(input);
+    expect(isValidSvelteAttribute(node as SvelteAttribute, settings)).toBe(
+      false,
+    );
   });
 });
 

--- a/src/utils/parser/visitors-validation.ts
+++ b/src/utils/parser/visitors-validation.ts
@@ -1,9 +1,14 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST as SvelteAST } from "svelte-eslint-parser";
 import { AST as VueAST } from "vue-eslint-parser";
 
 import type { SupportedAttribute, TextAttribute } from "../../types";
 import { type PluginSettings } from "../parse-plugin-settings";
-import { getJSXAttributeName, getVAttributeName } from "./node";
+import {
+  getJSXAttributeName,
+  getSvelteAttributeName,
+  getVAttributeName,
+} from "./node";
 
 /**
  * Validates a `JSXAttribute` for `eslint-plugin-tailwindcss`
@@ -30,6 +35,25 @@ export const isValidJSXAttribute = (
     }
   }
   // Valid JSXAttribute
+  return true;
+};
+
+/**
+ * Validates a `SvelteAttribute` for `eslint-plugin-tailwindcss`
+ * @returns `false` if the `SvelteAttribute` can be skipped.
+ */
+export const isValidSvelteAttribute = (
+  node: SvelteAST.SvelteAttribute,
+  settings: PluginSettings,
+): boolean => {
+  const attributes = (settings && settings.attributes) || [];
+  // Ignored SvelteAttribute
+  if (!attributes.includes(getSvelteAttributeName(node))) return false;
+  // No value
+  if (!node.value) return false;
+  if (node.value.length === 0) return false;
+  if (node.value.length === 1 && node.value[0].type !== "SvelteLiteral")
+    return false;
   return true;
 };
 

--- a/src/utils/parser/visitors-validation.ts
+++ b/src/utils/parser/visitors-validation.ts
@@ -52,8 +52,7 @@ export const isValidSvelteAttribute = (
   // No value
   if (!node.value) return false;
   if (node.value.length === 0) return false;
-  if (node.value.length === 1 && node.value[0].type !== "SvelteLiteral")
-    return false;
+  // TODO Svelte
   return true;
 };
 

--- a/src/utils/rule.spec.ts
+++ b/src/utils/rule.spec.ts
@@ -1,5 +1,8 @@
 import { parse } from "@typescript-eslint/parser";
 import { TSESTree } from "@typescript-eslint/utils";
+import { Literal } from "estree";
+import * as SvelteParser from "svelte-eslint-parser";
+import { SvelteName } from "svelte-eslint-parser/lib/ast";
 import { describe, expect, it } from "vitest";
 
 import { DEFAULT_SETTINGS, type PluginSettings } from "./parse-plugin-settings";
@@ -26,6 +29,40 @@ const getClassNameJSXAttributeNode = (ast: TSESTree.Program) => {
       attribute.name.type === "JSXIdentifier" &&
       attribute.name.name === "className",
   ) as TSESTree.JSXAttribute;
+};
+
+/**
+ * @example `<h1 className={...}>getClassNameSvelteAttributeNode</h1>`
+ */
+const getClassNameSvelteAttributeNode = (
+  ast: SvelteParser.AST.SvelteProgram,
+) => {
+  return (
+    (ast.body[0] as SvelteParser.AST.SvelteElement)
+      .startTag as SvelteParser.AST.SvelteStartTag
+  ).attributes.find(
+    (attribute) =>
+      attribute.type === "SvelteAttribute" &&
+      attribute.key.type === "SvelteName" &&
+      attribute.key.name === "class",
+  ) as SvelteParser.AST.SvelteAttribute;
+};
+
+/**
+ * @example `<h1 className={...}>getClassNameSvelteDirectiveNode</h1>`
+ */
+const getClassNameSvelteDirectiveNode = (
+  ast: SvelteParser.AST.SvelteProgram,
+) => {
+  return (
+    (ast.body[0] as SvelteParser.AST.SvelteElement)
+      .startTag as SvelteParser.AST.SvelteStartTag
+  ).attributes.find(
+    (attribute) =>
+      attribute.type === "SvelteDirective" &&
+      attribute.kind === "Class" &&
+      attribute.key.type === "SvelteDirectiveKey",
+  ) as SvelteParser.AST.SvelteDirective;
 };
 
 /**
@@ -73,6 +110,88 @@ describe("getLiteralsFromNode", () => {
 
       const result = getLiteralsFromNode(mockSettings, mockContext, node, node);
       expect(result.length).toBe(1);
+    });
+  });
+
+  describe("Using Svelte", () => {
+    describe("SvelteAttribute", () => {
+      it(`Simple: \`<div class="block absolute">...</div>\``, () => {
+        const parsed = SvelteParser.parseForESLint(
+          `<div class="block absolute">...</div>`,
+        );
+        const attribute = getClassNameSvelteAttributeNode(parsed.ast);
+        const result = getLiteralsFromNode(
+          mockSettings,
+          mockContext,
+          attribute,
+          attribute,
+        );
+        expect(result.length).toBe(1);
+        expect((result[0] as Literal).value).toBe("block absolute");
+      });
+    });
+    describe("SvelteDirective", () => {
+      it(`Simple: \`<div class:lg:block={true}>...</div>\``, () => {
+        const parsed = SvelteParser.parseForESLint(
+          `<div class:lg:block={true}>...</div>`,
+        );
+        const attribute = getClassNameSvelteDirectiveNode(parsed.ast);
+        const result = getLiteralsFromNode(
+          mockSettings,
+          mockContext,
+          // @ts-expect-error ...
+          attribute.key.name,
+          attribute.key.name,
+        );
+        expect(result.length).toBe(1);
+        expect((result[0] as SvelteName).name).toBe("lg:block");
+      });
+    });
+    describe("SvelteMustacheTag", () => {
+      it(`Object: \`class={{ "block absolute": shown, "size-0 invisible": !shown }}\``, () => {
+        const parsed = SvelteParser.parseForESLint(
+          `<div class={{ "block absolute": shown, "size-0 invisible": !shown }}>...</div>`,
+        );
+        const attribute = getClassNameSvelteAttributeNode(parsed.ast);
+        const result = getLiteralsFromNode(
+          mockSettings,
+          mockContext,
+          attribute,
+          attribute,
+        );
+        expect(result.length).toBe(2);
+        expect((result[0] as Literal).value).toBe("block absolute");
+        expect((result[1] as Literal).value).toBe("size-0 invisible");
+      });
+      it(`Array: \`class={[faded && 'saturate-0 opacity-50', large && 'scale-200']}\``, () => {
+        const parsed = SvelteParser.parseForESLint(
+          `<div class={[faded && 'saturate-0 opacity-50', large && 'scale-200']}>...</div>`,
+        );
+        const attribute = getClassNameSvelteAttributeNode(parsed.ast);
+        const result = getLiteralsFromNode(
+          mockSettings,
+          mockContext,
+          attribute,
+          attribute,
+        );
+        expect(result.length).toBe(2);
+        expect((result[0] as Literal).value).toBe("saturate-0 opacity-50");
+        expect((result[1] as Literal).value).toBe("scale-200");
+      });
+      it(`Array: \`class={['block absolute', props.class]}\``, () => {
+        const parsed = SvelteParser.parseForESLint(
+          `<div class={['block absolute', props.class]}>...</div>`,
+        );
+        const attribute = getClassNameSvelteAttributeNode(parsed.ast);
+        const result = getLiteralsFromNode(
+          mockSettings,
+          mockContext,
+          attribute,
+          attribute,
+        );
+        expect(result.length).toBe(1);
+        expect((result[0] as Literal).value).toBe("block absolute");
+      });
     });
   });
 

--- a/src/utils/rule.ts
+++ b/src/utils/rule.ts
@@ -1,5 +1,8 @@
 import { TSESTree } from "@typescript-eslint/utils";
 import { RuleListener } from "@typescript-eslint/utils/ts-eslint";
+import type ESTree from "estree";
+import { ConditionalExpression } from "estree";
+import { AST as SvelteAST } from "svelte-eslint-parser";
 import { AST as VueAST } from "vue-eslint-parser";
 
 import type { TextAttribute } from "../types";
@@ -13,6 +16,7 @@ import {
   isValidCallExpression,
   isValidExpressionAttributeValue,
   isValidJSXAttribute,
+  isValidSvelteAttribute,
   isValidTextAttribute,
   isValidVAttribute,
 } from "./parser/visitors-validation";
@@ -22,8 +26,17 @@ export type AtomicNode =
   | TSESTree.Identifier
   | TSESTree.Literal
   | TSESTree.TemplateElement
+  | SvelteAST.SvelteLiteral
   | VueAST.VAttribute
   | VueAST.VLiteral;
+
+type ParsingNode =
+  | ESTree.Expression
+  | TSESTree.Node
+  | SvelteAST.SvelteAttribute
+  | SvelteAST.SvelteLiteral
+  | SvelteAST.SvelteMustacheTag
+  | VueAST.VAttribute;
 
 /**
  * Recursively extracts literal nodes from the given AST node.
@@ -38,8 +51,8 @@ export type AtomicNode =
 export const getLiteralsFromNode = <TRuleContext>(
   settings: PluginSettings,
   context: TRuleContext,
-  node: TSESTree.Node | VueAST.VAttribute,
-  rootNode: TSESTree.Node | VueAST.VAttribute,
+  node: ParsingNode,
+  rootNode: ParsingNode,
   depth: number = 0,
   targetKeys: Array<string> = [],
 ): Array<AtomicNode> => {
@@ -167,6 +180,7 @@ export const getLiteralsFromNode = <TRuleContext>(
     case TSESTree.AST_NODE_TYPES.Literal: {
       if (typeof node.value !== "string") break;
       if (node.value === "") break;
+      // @ts-expect-error Property 'parent' is missing in type 'SimpleLiteral' but required in type 'StringLiteral'
       literals.push(node);
       break;
     }
@@ -265,6 +279,41 @@ export const getLiteralsFromNode = <TRuleContext>(
 
       break;
     }
+    case "SvelteAttribute": {
+      if (!isValidSvelteAttribute(node, settings)) break;
+      for (const element of node.value) {
+        if (!element) continue;
+        literals.push(
+          ...getLiteralsFromNode(
+            settings,
+            context,
+            element,
+            rootNode,
+            depth + 1,
+            targetKeys,
+          ),
+        );
+      }
+      break;
+    }
+    case "SvelteLiteral": {
+      if (typeof node.value !== "string") break;
+      if (node.value === "") break;
+      literals.push(node);
+      break;
+    }
+    case "SvelteMustacheTag": {
+      literals.push(
+        ...getLiteralsFromNode(
+          settings,
+          context,
+          node.expression as ConditionalExpression,
+          rootNode,
+          depth + 1,
+        ),
+      );
+      break;
+    }
   }
   return literals.filter((literal) => {
     if ("value" in literal) {
@@ -294,7 +343,6 @@ export const createScriptVisitors = <TRuleContext, TOptions>(
     literals: Array<AtomicNode>,
   ) => void,
 ): RuleListener => {
-  // console.log(options);
   return {
     /**
      * In JSX + inside <script> section of Vue SFC…
@@ -337,6 +385,11 @@ export const createScriptVisitors = <TRuleContext, TOptions>(
         jsxAttributeNode,
         0,
       );
+      lintLiterals(context, settings, options, literals);
+    },
+
+    SvelteAttribute(node: SvelteAST.SvelteAttribute) {
+      const literals = getLiteralsFromNode(settings, context, node, node, 0);
       lintLiterals(context, settings, options, literals);
     },
 

--- a/src/utils/rule.ts
+++ b/src/utils/rule.ts
@@ -27,6 +27,7 @@ export type AtomicNode =
   | TSESTree.Literal
   | TSESTree.TemplateElement
   | SvelteAST.SvelteLiteral
+  | SvelteAST.SvelteName
   | VueAST.VAttribute
   | VueAST.VLiteral;
 
@@ -34,8 +35,10 @@ type ParsingNode =
   | ESTree.Expression
   | TSESTree.Node
   | SvelteAST.SvelteAttribute
+  | SvelteAST.SvelteDirective
   | SvelteAST.SvelteLiteral
   | SvelteAST.SvelteMustacheTag
+  | SvelteAST.SvelteName
   | VueAST.VAttribute;
 
 /**
@@ -199,10 +202,11 @@ export const getLiteralsFromNode = <TRuleContext>(
     case TSESTree.AST_NODE_TYPES.ObjectExpression: {
       if (rootNode === undefined) return [];
 
-      const useKeys = isWithinCallee(
-        rootNode as TSESTree.Node,
-        settings.parseKeyFunctions, // clsx, classnames, etc.
-      );
+      const useKeys =
+        isWithinCallee(
+          rootNode as TSESTree.Node,
+          settings.parseKeyFunctions, // clsx, classnames, etc.
+        ) || rootNode.type === "SvelteAttribute";
       const isVue =
         rootNode.type === "VAttribute" &&
         rootNode.key &&
@@ -314,6 +318,12 @@ export const getLiteralsFromNode = <TRuleContext>(
       );
       break;
     }
+    case "SvelteName": {
+      if (typeof node.name !== "string") break;
+      if (node.name === "") break;
+      literals.push(node);
+      break;
+    }
   }
   return literals.filter((literal) => {
     if ("value" in literal) {
@@ -390,6 +400,21 @@ export const createScriptVisitors = <TRuleContext, TOptions>(
 
     SvelteAttribute(node: SvelteAST.SvelteAttribute) {
       const literals = getLiteralsFromNode(settings, context, node, node, 0);
+      lintLiterals(context, settings, options, literals);
+    },
+
+    SvelteDirective(node: SvelteAST.SvelteDirective) {
+      if (node.kind !== "Class") return;
+      if (node.key.type !== "SvelteDirectiveKey") return;
+      if (node.key.name.type !== "SvelteName") return;
+      if (!node.key.name.name) return;
+      const literals = getLiteralsFromNode(
+        settings,
+        context,
+        node.key.name,
+        node.key.name,
+        0,
+      );
       lintLiterals(context, settings, options, literals);
     },
 


### PR DESCRIPTION
# svelte-eslint-parser

## Description

@E021ntox, this might help you using the plugin with svelte files.

Make sure to:
- `npm i eslint-plugin-tailwindcss@4.3.0-svelte.beta.0`
- `npm i svelte-eslint-parser`
- configure your eslint to use `svelte-eslint-parser`

Please give it a try and give me some feedback.

You can take a look at the new tests added in this MR to check how it is supposed to work.