### PR TITLE
fix: add import.meta.url to paths in TailwindUtils

### DIFF
--- a/src/utils/tailwindcss-api/worker/candidates-to-css.mjs
+++ b/src/utils/tailwindcss-api/worker/candidates-to-css.mjs
@@ -19,7 +19,16 @@ runAsWorker(
      */
     className,
   ) => {
-    const utils = new TailwindUtils();
+    const utils = new TailwindUtils({
+      /**
+       * `tailwind-api-utils` attempts to load `tailwindcss` via the `local-pkg`
+       * package, which will attempt to resolve `tailwindcss` relative to its
+       * own `import.meta.url`. In a pnpm monorepo, where direct access to
+       * transitive dependencies in workspace packages is forbidden,
+       * `TailwindUtils` will fail to find the package if ran at the root
+       */
+      paths: [import.meta.url],
+    });
     await utils.loadConfigV4(cssConfigPath);
     if (!utils.context) {
       throw new Error(

--- a/src/utils/tailwindcss-api/worker/get-sorted-class-names.mjs
+++ b/src/utils/tailwindcss-api/worker/get-sorted-class-names.mjs
@@ -19,7 +19,7 @@ runAsWorker(
      */
     unorderedClassNames,
   ) => {
-    const utils = new TailwindUtils();
+    const utils = new TailwindUtils({ paths: [import.meta.url] });
     await utils.loadConfigV4(cssConfigPath);
     if (!utils.context) {
       throw new Error(

--- a/src/utils/tailwindcss-api/worker/is-valid-class-name.mjs
+++ b/src/utils/tailwindcss-api/worker/is-valid-class-name.mjs
@@ -19,7 +19,7 @@ runAsWorker(
      */
     className,
   ) => {
-    const utils = new TailwindUtils();
+    const utils = new TailwindUtils({ paths: [import.meta.url] });
     await utils.loadConfigV4(cssConfigPath);
     if (!utils.context) {
       throw new Error(

--- a/src/utils/tailwindcss-api/worker/load-theme.mjs
+++ b/src/utils/tailwindcss-api/worker/load-theme.mjs
@@ -15,7 +15,7 @@ runAsWorker(
      */
     cssConfigPath,
   ) => {
-    const utils = new TailwindUtils();
+    const utils = new TailwindUtils({ paths: [import.meta.url] });
     await utils.loadConfigV4(cssConfigPath);
     if (!utils.context) {
       throw new Error(


### PR DESCRIPTION
# fix: add import.meta.url to paths in TailwindUtils

## Description

- In a pnpm monorepo (and probably other systems that don't allow direct use of transitive dependencies of workspace packages), `TailwindUtils` will error when used at the root (`Error: Could not find tailwindcss`) (https://github.com/hyoban/tailwind-api-utils/blob/25c9a5777dfe74bfca00effaafb9c9c0a8f6be39/src/index.ts#L19-L22)
- When `load-pkg` attempts to load Tailwind CSS, it does so relative to its own `import.meta.url`, which does not have access to `tailwindcss`. Adding the `import.meta.url` of `eslint-plugin-tailwindcss` (which does have Tailwind CSS as a peer dependency) in `tailwind-api-utils` fixes this.

Fixes #445 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I can't exactly test it in Vitest, but here's a reproduction: https://github.com/jeremy-code/tailwind-eslint-pnpm where I used pnpm patches to fix the issue.

Before:
```shell
$ eslint apps/client/index.js

Oops! Something went wrong! :(

ESLint: 10.8.0

Error: Could not find tailwindcss
    at new TailwindUtils (file:///$HOME/tailwind-eslint-pnpm/node_modules/.pnpm/tailwind-api-utils@1.0.3_tailwindcss@4.3.3/node_modules/tailwind-api-utils/dist/index.mjs:365:13)
    at file:///$HOME/tailwind-eslint-pnpm/node_modules/.pnpm/eslint-plugin-tailwindcss@4.2.0_eslint@10.8.0_jiti@2.7.0__tailwindcss@4.3.3_typescript@6.0.3/node_modules/eslint-plugin-tailwindcss/lib/worker/get-sorted-class-names.mjs:22:19
    at file:///$HOME/tailwind-eslint-pnpm/node_modules/.pnpm/synckit@0.11.13/node_modules/synckit/lib/index.js:47:50
    at MessagePort.<anonymous> (file:///$HOME/tailwind-eslint-pnpm/node_modules/.pnpm/synckit@0.11.13/node_modules/synckit/lib/index.js:65:11)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:843:20)
    at MessagePort.<anonymous> (node:internal/per_context/messageport:23:28)
[ELIFECYCLE] Command failed with exit code 2.
```

After:
```
$ eslint apps/client/index.js

/Users/jeremy/Github/tailwind-eslint-pnpm/apps/client/index.js
  4:25  warning  Invalid Tailwind CSS classnames order                  tailwindcss/classnames-order
  4:25  warning  'w-full' can be merged with 'h-full' into 'size-full'  tailwindcss/enforces-shorthand
  4:32  warning  Invalid Tailwind CSS classnames order                  tailwindcss/classnames-order
  4:32  warning  'h-full' can be merged with 'w-full' into 'size-full'  tailwindcss/enforces-shorthand

✖ 4 problems (0 errors, 4 warnings)
  0 errors and 3 warnings potentially fixable with the `--fix` option.
```

It also passes all existing tests.

**Test Configuration**:

- OS + version: macOS Tahoe Version 26.5.2
- NPM version: 11.16.0
- Node version: v24.18.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings