### PR TITLE
perf(no-unnecessary-arbitrary-value): index theme presents by value

### DIFF
--- a/src/rules/no-unnecessary-arbitrary-value.ts
+++ b/src/rules/no-unnecessary-arbitrary-value.ts
@@ -13,7 +13,7 @@ import urlCreator from "../url-creator";
 import { compressTailwindArbitrary } from "../utils/compress-tailwind-arbitrary";
 import {
   getThemeKeyPrefixesFromClassname,
-  getThemePresetsFromPrefixes,
+  getThemePresetNamesByArbitraryValue,
 } from "../utils/get-theme-key-prefixes-from-classname";
 import { joiner } from "../utils/joiner";
 import { joinListElements } from "../utils/list-formatter";
@@ -40,7 +40,6 @@ import {
   createTemplateVisitors,
 } from "../utils/rule";
 import { loadThemeWorker } from "../utils/tailwindcss-api";
-import { toTailwindArbitrary } from "../utils/to-tailwind-arbitrary";
 import { convertStringValueToPx } from "../utils/units";
 
 export const RULE_NAME = "no-unnecessary-arbitrary-value";
@@ -88,6 +87,11 @@ const checkArbitraryClassnames = (
     settings,
   );
 
+  // Only depends on the theme, so resolve it once
+  const spacingValue =
+    `${theme.values.get("--spacing")?.value ?? ""}` || "0.25rem";
+  const spacingValueInPx = convertStringValueToPx(spacingValue);
+
   for (const node of literals) {
     const { originalClassNamesValue, start, end, prefix, suffix } =
       dissectAtomicNode(node, genericContext);
@@ -129,12 +133,14 @@ const checkArbitraryClassnames = (
       // Should not happen, but just in case
       if (prefixes.size === 0) continue;
 
-      // Retrieves all the possible keys
-      const presetKeys = getThemePresetsFromPrefixes(theme, prefixes);
       const acceptGenericNumberSuffix = allowsGenericNumbers(absBaseClass);
       const { classPrefix = "", arbitraryValue = "" } = match.groups;
       const compressedArbitraryValue =
         compressTailwindArbitrary(arbitraryValue);
+      const { minusSign, cleanedValue } = resolveValueSign(
+        compressedArbitraryValue,
+        !!negativePrefix,
+      );
       const matchingPresets: Array<string> = [];
 
       // 1. Check for px native presets e.g. `my-[1px]` → `my-px`
@@ -142,31 +148,21 @@ const checkArbitraryClassnames = (
         ["-1px", "1px"].includes(compressedArbitraryValue) &&
         hasPxNativePreset(absBaseClass)
       ) {
-        const { minusSign } = resolveValueSign(
-          compressedArbitraryValue,
-          !!negativePrefix,
-        );
         matchingPresets.push(`${modifiers}${minusSign}${classPrefix}-px`);
       }
 
       // 2. Looking into the defined presets for EXACT preset matches
       for (const currentPrefix of prefixes) {
-        for (const [presetKey, presetValue] of presetKeys.entries()) {
-          // Does not match
-          if (!presetKey.startsWith(currentPrefix)) continue;
+        const presetNames = getThemePresetNamesByArbitraryValue(
+          theme,
+          currentPrefix,
+        ).get(cleanedValue);
+        if (presetNames === undefined) continue;
 
-          const compressedPresetValue = toTailwindArbitrary(presetValue);
-          const { minusSign, cleanedValue } = resolveValueSign(
-            compressedArbitraryValue,
-            !!negativePrefix,
+        for (const presetName of presetNames) {
+          matchingPresets.push(
+            `${modifiers}${minusSign}${classPrefix}-${presetName}${bang}`,
           );
-
-          if (compressedPresetValue === cleanedValue) {
-            const presetName = presetKey.slice(currentPrefix.length);
-            matchingPresets.push(
-              `${modifiers}${minusSign}${classPrefix}-${presetName}${bang}`,
-            );
-          }
         }
       }
 
@@ -175,10 +171,6 @@ const checkArbitraryClassnames = (
         acceptGenericNumberSuffix &&
         /^-?\d+(?:\.\d+)?$/.test(compressedArbitraryValue)
       ) {
-        const { minusSign, cleanedValue } = resolveValueSign(
-          compressedArbitraryValue,
-          !!negativePrefix,
-        );
         matchingPresets.push(
           `${modifiers}${minusSign}${classPrefix}-${cleanedValue}${bang}`,
         );
@@ -186,18 +178,6 @@ const checkArbitraryClassnames = (
 
       // 4. Check for spacing based presets e.g. `my-[2px]` → `my-2`
       if (supportsSpacing(absBaseClass)) {
-        const spacingPresets = getThemePresetsFromPrefixes(
-          theme,
-          new Set(["--spacing"]),
-        );
-        const spacingValue = spacingPresets.get("--spacing") || "0.25rem";
-
-        const { minusSign, cleanedValue } = resolveValueSign(
-          compressedArbitraryValue,
-          !!negativePrefix,
-        );
-
-        const spacingValueInPx = convertStringValueToPx(spacingValue);
         const valueInPx = convertStringValueToPx(cleanedValue);
 
         if (valueInPx !== undefined && spacingValueInPx !== undefined) {

--- a/src/utils/get-theme-key-prefixes-from-classname.spec.ts
+++ b/src/utils/get-theme-key-prefixes-from-classname.spec.ts
@@ -4,6 +4,7 @@ import { withAllPresetsSettings } from "../utils/parser/test-helpers";
 import { loadThemeWorker } from "../utils/tailwindcss-api";
 import {
   getThemeKeyPrefixesFromClassname,
+  getThemePresetNamesByArbitraryValue,
   getThemePresetsFromPrefixes,
 } from "./get-theme-key-prefixes-from-classname";
 
@@ -622,4 +623,48 @@ test(`Get the preset keys/values from prefixes`, () => {
   ].map(({ prefixes, presets }) => {
     expect(getThemePresetsFromPrefixes(theme, prefixes)).toEqual(presets);
   });
+});
+
+test(`Get the theme preset names by arbitrary value`, () => {
+  [
+    // `--aspect-square: 1 / 1` and `--aspect-one-to-one: 1/1` normalize to the
+    // same value, so both are suggested, in theme order
+    {
+      prefix: "--aspect-",
+      arbitraryValue: "1/1",
+      presetNames: ["square", "one-to-one"],
+    },
+    {
+      prefix: "--aspect-",
+      arbitraryValue: "4/3",
+      presetNames: ["retro"],
+    },
+    // A nested key keeps the rest of its name
+    {
+      prefix: "--stroke-",
+      arbitraryValue: "0.5",
+      presetNames: ["width-hairline"],
+    },
+    // Spaces within a value become underscores
+    {
+      prefix: "--text-",
+      arbitraryValue: "1.5rem",
+      presetNames: ["tiny--line-height"],
+    },
+    // No preset uses this value
+    {
+      prefix: "--aspect-",
+      arbitraryValue: "16/10",
+      presetNames: undefined,
+    },
+  ].map(({ prefix, arbitraryValue, presetNames }) => {
+    expect(
+      getThemePresetNamesByArbitraryValue(theme, prefix).get(arbitraryValue),
+    ).toEqual(presetNames);
+  });
+
+  // The index is memoized per theme + prefix
+  expect(getThemePresetNamesByArbitraryValue(theme, "--aspect-")).toBe(
+    getThemePresetNamesByArbitraryValue(theme, "--aspect-"),
+  );
 });

--- a/src/utils/get-theme-key-prefixes-from-classname.ts
+++ b/src/utils/get-theme-key-prefixes-from-classname.ts
@@ -1,5 +1,12 @@
 import { getBaseClassname } from "./parser/classname";
 import { type Theme } from "./tailwindcss-api/types";
+import { toTailwindArbitrary } from "./to-tailwind-arbitrary";
+
+// A `Theme` never changes once loaded, so anything derived from it is memoized.
+const themePresetNamesByValueCache = new WeakMap<
+  Theme,
+  Map<string, Map<string, Array<string>>>
+>();
 
 /**
  * Retrieves the possible theme key prefixes for a given classname.
@@ -360,4 +367,40 @@ export const getThemePresetsFromPrefixes = (
     }
   }
   return presets;
+};
+
+/**
+ * Maps each preset value, in its arbitrary form, to the preset names using it,
+ * so matching a class against the theme is a lookup instead of a full scan.
+ * @param theme The theme object.
+ * @param prefix The theme key prefix, e.g. `--aspect-`.
+ * @returns A shared, read-only map of arbitrary values to preset names.
+ * @example `--aspect-video: 16 / 9` would return `Map { "16/9" => ["video"] }`
+ */
+export const getThemePresetNamesByArbitraryValue = (
+  theme: Theme,
+  prefix: string,
+): Map<string, Array<string>> => {
+  let cachedByPrefix = themePresetNamesByValueCache.get(theme);
+  if (cachedByPrefix === undefined) {
+    cachedByPrefix = new Map();
+    themePresetNamesByValueCache.set(theme, cachedByPrefix);
+  }
+  const cached = cachedByPrefix.get(prefix);
+  if (cached !== undefined) return cached;
+
+  const presetNamesByValue = new Map<string, Array<string>>();
+  for (const [key, preset] of theme.values) {
+    if (!key.startsWith(prefix)) continue;
+    const arbitraryValue = toTailwindArbitrary(`${preset.value}`);
+    const presetName = key.slice(prefix.length);
+    const presetNames = presetNamesByValue.get(arbitraryValue);
+    if (presetNames === undefined) {
+      presetNamesByValue.set(arbitraryValue, [presetName]);
+    } else {
+      presetNames.push(presetName);
+    }
+  }
+  cachedByPrefix.set(prefix, presetNamesByValue);
+  return presetNamesByValue;
 };


### PR DESCRIPTION
Each arbitrary class name caused the `no-unnecessary-arbitrary-value` rule to rescan the entire theme and re-run `toTailwindArbitrary` on each preset value. This made the work `0(classes x theme entries)` with 2 regexes per entry.

Now we build the reverse index once per theme/prefix combo instead to save having to rescan.

Fixes #466 (it may not fix the OP's issue entirely, but contributes a significant reduction in lint time)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Benchmarked locally on 120 Vue files (9600 class attributes, arbitrary-value heavy):

* default theme (419 entries), 4.8s -> 2.0s
* large theme (1619 entries), 9.3s -> 2.0s

**Test Configuration**:

- OS + version: macOS Tahoe 26.5.1
- NPM version: 11.6.2
- Node version: 24.12.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
