### PR TITLE
fix: avoid invalid decimal arbitrary value suggestions

### DIFF
--- a/src/rules/no-unnecessary-arbitrary-value.spec.ts
+++ b/src/rules/no-unnecessary-arbitrary-value.spec.ts
@@ -2,7 +2,10 @@ import * as Parser from "@typescript-eslint/parser";
 import { RuleTester, TestCaseError } from "@typescript-eslint/rule-tester";
 
 import { joinListElements } from "../utils/list-formatter";
-import { withAllPresetsSettings } from "../utils/parser/test-helpers";
+import {
+  emptySettings,
+  withAllPresetsSettings,
+} from "../utils/parser/test-helpers";
 import {
   type MessageIds,
   noUnnecessaryArbitraryValue,
@@ -62,14 +65,25 @@ ruleTester.run(RULE_NAME, noUnnecessaryArbitraryValue, {
     // JSX
     [
       // Not an arbitrary value
-      "ctl('m-0')",
+      {
+        code: "ctl('m-0')",
+        settings: { tailwindcss: withAllPresetsSettings },
+      },
       // Not an existing preset
-      "ctl('m-[calc(123456789px)]')",
-      `<div class="my-[3.14px] ml-1 mr-px">Issue #366</div>`,
-    ].map((testedJsxCode) => ({
-      code: testedJsxCode,
-      settings: { tailwindcss: withAllPresetsSettings },
-    })),
+      {
+        code: "ctl('m-[calc(123456789px)]')",
+        settings: { tailwindcss: withAllPresetsSettings },
+      },
+      {
+        code: `<div class="my-[3.14px] ml-1 mr-px">Issue #366</div>`,
+        settings: { tailwindcss: withAllPresetsSettings },
+      },
+      // `leading-1.125` is not a valid Tailwind CSS v4 class (Issue #469).
+      {
+        code: `<div class="leading-[1.125]">Issue #469</div>`,
+        settings: { tailwindcss: emptySettings },
+      },
+    ],
   invalid: [
     // Single errors + withAllPresetsSettings
     ...[

--- a/src/rules/no-unnecessary-arbitrary-value.ts
+++ b/src/rules/no-unnecessary-arbitrary-value.ts
@@ -39,7 +39,10 @@ import {
   createScriptVisitors,
   createTemplateVisitors,
 } from "../utils/rule";
-import { loadThemeWorker } from "../utils/tailwindcss-api";
+import {
+  isValidClassNameWorker,
+  loadThemeWorker,
+} from "../utils/tailwindcss-api";
 import { toTailwindArbitrary } from "../utils/to-tailwind-arbitrary";
 import { convertStringValueToPx } from "../utils/units";
 
@@ -179,9 +182,18 @@ const checkArbitraryClassnames = (
           compressedArbitraryValue,
           !!negativePrefix,
         );
-        matchingPresets.push(
-          `${modifiers}${minusSign}${classPrefix}-${cleanedValue}${bang}`,
-        );
+        const genericPreset = `${modifiers}${minusSign}${classPrefix}-${cleanedValue}${bang}`;
+        if (
+          !cleanedValue.includes(".") ||
+          isValidClassNameWorker(
+            settings.cssConfigPath,
+            context.filename,
+            genericPreset,
+            settings,
+          )
+        ) {
+          matchingPresets.push(genericPreset);
+        }
       }
 
       // 4. Check for spacing based presets e.g. `my-[2px]` → `my-2`


### PR DESCRIPTION
## Summary

- Avoid suggesting decimal generic class names when the normalized Tailwind CSS v4 candidate is invalid.
- Preserve existing integer and theme preset suggestions while checking decimal candidates against Tailwind's class validator.
- Add regression coverage for `leading-[1.125]`, which must remain arbitrary instead of being changed to invalid `leading-1.125`.

## Testing

- `pnpm exec vitest run src/rules/no-unnecessary-arbitrary-value.spec.ts`
- `pnpm run lint`
- `pnpm exec unbuild --config unbuild.config.ts`
- Built-package ESLint smoke test for `leading-[1.125]` (0 errors, 0 warnings)

Closes #469
